### PR TITLE
Making the Shotgun objects inherit from object

### DIFF
--- a/shotgun_api3.py
+++ b/shotgun_api3.py
@@ -153,7 +153,7 @@ class Shotgun(object):
 
     def __init__(self, base_url, script_name, api_key, convert_datetimes_to_utc=True, http_proxy=None):
         """
-z       Initialize Shotgun.
+        Initialize Shotgun.
         """
         self.server = None
         if base_url.split("/")[0] not in ("http:","https:"):


### PR DESCRIPTION
If anyone is using less than Python 2.2, this patch will break them. However, inheriting from object allows us to use "new style class" features, like property getters and setters. Here's some more info:
http://docs.python.org/release/2.5.2/ref/node33.html

Also this gives me an excuse to try out the new pull request features.

--alex
