### PR TITLE
More permissive type checking

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -23,6 +23,10 @@ Some useful direct links within this section are below:
 * [Reference: Filter Syntax](https://github.com/shotgunsoftware/python-api/wiki/Reference%3A-Filter-Syntax)
 
 ## Changelog
+**v3.0.6 - 2010 Jan 25**
+ 
+  + optimization: don't request paging_info unless required (and server support is available)
+
 **v3.0.5 - 2010 Dec 20**
  
   + officially remove support for old api3_preview controller


### PR DESCRIPTION
Should still be Python 2.4 compatible.

Tested with some code of mine that subclasses dict to represent Shotgun objects and these were accepted as dicts by the API and XML-RPC marshaller.
