### PR TITLE
Replace platform with sys.platform

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -38,7 +38,6 @@ import logging
 import mimetools    # used for attachment upload
 import mimetypes    # used for attachment upload
 import os
-import platform
 import re
 import stat         # used for attachment upload
 import sys
@@ -138,11 +137,13 @@ class ClientCapabilities(object):
     """
     
     def __init__(self):
-        system = platform.system().lower()
-        if system == 'darwin':
-            self.platform = "mac"
-        elif system in ('windows','linux'):
-            self.platform = system
+        system = sys.platform.lower()
+        if system == 'win32':
+            self.platform = 'windows'
+        elif system == 'darwin':
+            self.platform = 'mac'
+        elif system.startswith('linux'):
+            self.platform = 'linux'  
         else:
             self.platform = None
         


### PR DESCRIPTION
Using the platform module is a trap. We have had nothing but problems from the platform module in python.  It crashes Maya 2009 for us.

You guys are not using it for much.  I would recommend replacing it with sys.platform.
