### PR TITLE
[#16241] catch error if server doesn't respond to info() method

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -115,12 +115,15 @@ class ServerCapabilities(object):
 
         #Version from server is major.minor.rev or major.minor.rev."Dev"
         #Store version as triple and check dev flag
-        self.version = meta.get("version", None)
+        try:
+            self.version = meta.get("version", None)
+        except AttributeError:
+            self.version = None
         if not self.version:
             raise ShotgunError("The Shotgun Server didn't respond with a version number. "
                                "This may be because you are running an older version of "
                                "Shotgun against a more recent version of the Shotgun API. "
-                               "For more information, please contact the Shotgun Support.")
+                               "For more information, please contact Shotgun Support.")
 
         if len(self.version) > 3 and self.version[3] == "Dev":
             self.is_dev = True


### PR DESCRIPTION
error occurs when using latest version of the API against older versions of Shotgun that don't respond to the `info()` method. 
