### PR TITLE
#18999 fix for Travis test failures

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -30,6 +30,7 @@ class TestBase(unittest.TestCase):
         self.ticket         = None
         self.human_password = None
         self.server_url     = None
+        self.server_address = None
         self.connect        = False
 
 
@@ -52,14 +53,6 @@ class TestBase(unittest.TestCase):
 
         if self.config.session_uuid:
             self.sg.set_session_uuid(self.config.session_uuid)
-
-        if self.sg.server_caps.version and \
-           self.sg.server_caps.version >= (3, 3, 0) and \
-           (self.sg.server_caps.host.startswith('0.0.0.0') or \
-            self.sg.server_caps.host.startswith('127.0.0.1')):
-                self.server_address = re.sub('^0.0.0.0|127.0.0.1', 'localhost', self.sg.server_caps.host)
-        else:
-            self.server_address = self.sg.server_caps.host
 
 
     def tearDown(self):
@@ -174,6 +167,13 @@ class LiveTestBase(TestBase):
         super(LiveTestBase, self).setUp()
         self.sg_version = self.sg.info()['version'][:3]
         self._setup_db(self.config)
+        if self.sg.server_caps.version and \
+           self.sg.server_caps.version >= (3, 3, 0) and \
+           (self.sg.server_caps.host.startswith('0.0.0.0') or \
+            self.sg.server_caps.host.startswith('127.0.0.1')):
+                self.server_address = re.sub('^0.0.0.0|127.0.0.1', 'localhost', self.sg.server_caps.host)
+        else:
+            self.server_address = self.sg.server_caps.host
 
     def _setup_db(self, config):
         data = {'name':self.config.project_name}


### PR DESCRIPTION
move server_address to LiveTestBase to fix Travis failures since it's only needed for tests that have a server #18999
