### PR TITLE
Fixed bug where cacerts.txt was not getting copied on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,7 @@ setup(
     url='https://github.com/shotgunsoftware/python-api',
     license=license,
     packages=find_packages(exclude=('tests',)),
-    script_args=script_args
+    script_args=script_args,
+    include_package_data=True,
+    package_data={'': [ 'cacerts.txt']},
 )


### PR DESCRIPTION
The subject kind of says it all.
