### PR TITLE
#19830 fix sharing thumbnail from source entity with no thumbnail

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -984,7 +984,11 @@ class Shotgun(object):
             if not str(result).startswith("1"):
                 raise ShotgunError("Unable to share thumbnail: %s" % result)
             else:
-                attachment_id = int(str(result).split(":")[1].split("\n")[0])
+                # clearing thumbnail returns no attachment_id
+                try:
+                    attachment_id = int(str(result).split(":")[1].split("\n")[0])
+                except ValueError:
+                    attachment_id = None
 
         return attachment_id
 


### PR DESCRIPTION
no attachment id is returned when sharing a thumbnail from a source entity that has no thumbnail. This effectively clears the thumbnail on all provided entities. Catch for this and return None instead.
