### PR TITLE
Better user-agent strings and management.

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -251,6 +251,8 @@ class Shotgun(object):
         self.config.api_path = urlparse.urljoin(urlparse.urljoin(
             api_base or "/", self.config.api_ver + "/"), "json")
 
+        self.reset_user_agent()
+
         # if the service contains user information strip it out
         # copied from the xmlrpclib which turned the user:password into
         # and auth header
@@ -894,6 +896,21 @@ class Shotgun(object):
 
         return self._call_rpc("schema_field_delete", params)
 
+    def add_user_agent(self, agent):
+        """Add agent to the user-agent header
+
+        Append agent to the string passed in as the user-agent to be logged
+        in events for this API session.
+
+        :param agent: Required, string to append to user-agent.
+        """
+        self._user_agents.append(agent)
+
+    def reset_user_agent(self):
+        """Reset user agent to the default
+        """
+        self._user_agents = ["shotgun-json (%s)" % __version__]
+
     def set_session_uuid(self, session_uuid):
         """Sets the browser session_uuid for this API session.
 
@@ -1311,7 +1328,7 @@ class Shotgun(object):
 
         attempt = 0
         req_headers = {
-            "user-agent" : "shotgun-json",
+            "user-agent": "; ".join(self._user_agents),
         }
         if self.config.authorization:
             req_headers["Authorization"] = self.config.authorization

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,6 +153,31 @@ class TestShotgunClient(base.MockTestBase):
         expected = "Basic " + base64.encodestring(login_password).strip()
         self.assertEqual(expected, headers.get("Authorization"))
 
+    def test_user_agent(self):
+        """User-Agent passed to server"""
+        # test default user agent
+        self.sg.info()
+        args, _ = self.sg._http_request.call_args
+        (_, _, _, headers) = args
+        expected = "shotgun-json (%s)" % api.__version__
+        self.assertEqual(expected, headers.get("user-agent"))
+
+        # test adding to user agent
+        self.sg.add_user_agent("test-agent")
+        self.sg.info()
+        args, _ = self.sg._http_request.call_args
+        (_, _, _, headers) = args
+        expected = "shotgun-json (%s); test-agent" % api.__version__
+        self.assertEqual(expected, headers.get("user-agent"))
+
+        # test resetting user agent
+        self.sg.reset_user_agent()
+        self.sg.info()
+        args, _ = self.sg._http_request.call_args
+        (_, _, _, headers) = args
+        expected = "shotgun-json (%s)" % api.__version__
+        self.assertEqual(expected, headers.get("user-agent"))
+
     def test_connect_close(self):
         """Connection is closed and opened."""
         #The mock created an existing mock connection,


### PR DESCRIPTION
Changed default user-agent to include api version.  Added add_user_agent and reset_user_agent methods to allow client code to add strings to track.
