### PR TITLE
Ticket #23960 make tests run with python 2.4

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -279,7 +279,8 @@ class Shotgun(object):
             if api_key is None:
                 raise ValueError("script_name provided without api_key")
 
-        if all(v is None for v in [script_name, api_key, login, password]):
+        # Can't use 'all' with python 2.4
+        if len([x for x in [script_name, api_key, login, password] if x]) == 0:
             if connect:
                 raise ValueError("must provide either login/password "
                                  "or script_name/api_key")

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,14 +3,11 @@ import re
 import unittest
 from ConfigParser import ConfigParser
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 import mock
 
 import shotgun_api3 as api
+from shotgun_api3.shotgun import json
 from shotgun_api3.shotgun import ServerCapabilities
 
 CONFIG_PATH = 'tests/config'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -373,7 +373,9 @@ class TestShotgunApi(base.LiveTestBase):
 
         shot_url = urlparse.urlparse(response_shot_thumbnail.get('image'))
         version_url = urlparse.urlparse(response_version_thumbnail.get('image'))
-        self.assertEqual(shot_url.path, version_url.path)
+        shot_path = _get_path(shot_url)
+        version_path = _get_path(version_url)
+        self.assertEqual(shot_path, version_path)
 
         # share thumbnail from source entity with entities
         source_thumbnail_id = self.sg.upload_thumbnail("Version",
@@ -401,8 +403,12 @@ class TestShotgunApi(base.LiveTestBase):
         version_url = urlparse.urlparse(response_version_thumbnail.get('image'))
         asset_url = urlparse.urlparse(response_asset_thumbnail.get('image'))
 
-        self.assertEqual(version_url.path, shot_url.path)
-        self.assertEqual(version_url.path, asset_url.path)
+        shot_path = _get_path(shot_url)
+        version_path = _get_path(version_url)
+        asset_path = _get_path(asset_url)
+
+        self.assertEqual(version_path, shot_path)
+        self.assertEqual(version_path, asset_path)
 
         # raise errors when missing required params or providing conflicting ones
         self.assertRaises(shotgun_api3.ShotgunError, self.sg.share_thumbnail,
@@ -1422,6 +1428,14 @@ def  _has_unicode(data):
             return True
     return False
 
+def _get_path(url):
+    # url_parse returns native objects for older python versions (2.4)
+    if isinstance(url, dict):
+        return url.get('path')
+    elif isinstance(url, tuple):
+        return os.path.join(url[:4])
+    else:
+        return url.path
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_api_long.py
+++ b/tests/test_api_long.py
@@ -85,4 +85,5 @@ class TestShotgunApiLong(base.LiveTestBase):
         ret_val = self.sg.schema_field_delete("Version", new_field_name)
         self.assertTrue(ret_val)
         
-   
+if __name__ == '__main__': 
+    base.unittest.main()


### PR DESCRIPTION
Made changes to get tests to run in python 2.4. Status can go back to ip after code review.
