### PR TITLE
23960 make tests windows friendly

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,10 +161,10 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertEqual(orig_file, attach_file)
 
         # test download with attachment_id (write to disk)
-	file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sg_logo_download.jpg")
+        file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sg_logo_download.jpg")
         result = self.sg.download_attachment(attach_id, file_path=file_path)
         self.assertEqual(result, file_path)
-	# On windows read may not read to end of file unless opened 'rb'
+    	# On windows read may not read to end of file unless opened 'rb'
         fp = open(file_path, 'rb')
         attach_file = fp.read()
         fp.close()


### PR DESCRIPTION
For some reason on windows the file.read wasn't going to the end of the files. Now tests pass on windows.
