### PR TITLE
for #25762: Add platform and python version info to user-agent

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -323,7 +323,6 @@ class Shotgun(object):
         self.config.api_path = urlparse.urljoin(urlparse.urljoin(
             api_base or "/", self.config.api_ver + "/"), "json")
 
-        self.reset_user_agent()
 
         # if the service contains user information strip it out
         # copied from the xmlrpclib which turned the user:password into
@@ -359,9 +358,12 @@ class Shotgun(object):
             self._json_loads = self._json_loads_ascii
 
         self.client_caps = ClientCapabilities()
+        # this relies on self.client_caps being set first 
+        self.reset_user_agent()
+
         self._server_caps = None
-        #test to ensure the the server supports the json API
-        #call to server will only be made once and will raise error
+        # test to ensure the the server supports the json API
+        # call to server will only be made once and will raise error
         if connect:
             self.server_caps
 
@@ -1065,8 +1067,14 @@ class Shotgun(object):
 
     def reset_user_agent(self):
         """Reset user agent to the default
+
+        Eg. shotgun-json (3.0.17); Python 2.6 (Mac)
         """
-        self._user_agents = ["shotgun-json (%s)" % __version__]
+        ua_platform = "Unknown"
+        if self.client_caps.platform is not None:
+            ua_platform = self.client_caps.platform.capitalize()
+        self._user_agents = ["shotgun-json (%s)" % __version__,
+                             "Python %s (%s)" % (self.client_caps.py_version, ua_platform)]
 
     def set_session_uuid(self, session_uuid):
         """Sets the browser session_uuid for this API session.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -157,9 +157,13 @@ class TestShotgunClient(base.MockTestBase):
         """User-Agent passed to server"""
         # test default user agent
         self.sg.info()
+        client_caps = self.sg.client_caps
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s)" % api.__version__
+        expected = "shotgun-json (%s); Python %s (%s)" % (api.__version__, 
+                                                          client_caps.py_version,
+                                                          client_caps.platform.capitalize()
+                                                          )
         self.assertEqual(expected, headers.get("user-agent"))
 
         # test adding to user agent
@@ -167,7 +171,11 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); test-agent" % api.__version__
+        expected = "shotgun-json (%s); Python %s (%s); test-agent" % (
+                        api.__version__, 
+                        client_caps.py_version,
+                        client_caps.platform.capitalize()
+                        )
         self.assertEqual(expected, headers.get("user-agent"))
 
         # test resetting user agent
@@ -175,7 +183,10 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s)" % api.__version__
+        expected = "shotgun-json (%s); Python %s (%s)" % (api.__version__, 
+                                                          client_caps.py_version,
+                                                          client_caps.platform.capitalize(),
+                                                          )
         self.assertEqual(expected, headers.get("user-agent"))
 
     def test_connect_close(self):


### PR DESCRIPTION
Adding the platform that the script is running on, and python version in order to be a little more consistent with the user-agent that any typical browser would send.

There's also server-side code that attempts to assign the platform for the current user. Since the API doesn't send any information that helps the server determine what platform it's running from, the server sets it to blank. This could possibly cause issues when doing things like matching against LocalStorage paths, etc. which require platform information.

Old default user agent string: `shotgun-json (3.0.17)`
New default user agent string: `shotgun-json (3.0.17); Python 2.6 (Mac)`
