### PR TITLE
IronPython support for POODLE vulnerability and side by side usage

### DIFF
--- a/shotgun_api3/lib/httplib2/__init__.py
+++ b/shotgun_api3/lib/httplib2/__init__.py
@@ -74,7 +74,8 @@ try:
         # doesn't expose the necessary knobs. So we need to go with the default
         # of SSLv23.
         return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
-                               cert_reqs=cert_reqs, ca_certs=ca_certs)
+                               cert_reqs=cert_reqs, ca_certs=ca_certs,
+                               ssl_version=ssl.PROTOCOL_TLSv1)
 except (AttributeError, ImportError):
     ssl_SSLError = None
     def _ssl_wrap_socket(sock, key_file, cert_file,

--- a/shotgun_api3/lib/httplib2/iri2uri.py
+++ b/shotgun_api3/lib/httplib2/iri2uri.py
@@ -12,6 +12,7 @@ __license__ = "MIT"
 __history__ = """
 """
 
+import sys
 import urlparse
 
 
@@ -68,7 +69,8 @@ def iri2uri(uri):
     the IRI before passing it into the function.""" 
     if isinstance(uri ,unicode):
         (scheme, authority, path, query, fragment) = urlparse.urlsplit(uri)
-        authority = authority.encode('idna')
+        encoding_scheme = 'idna' if not sys.platform == "cli" else 'utf-8'
+        authority = authority.encode(encoding_scheme)
         # For each character in 'ucschar' or 'iprivate'
         #  1. encode as utf-8
         #  2. then %-encode each octet of that utf-8 


### PR DESCRIPTION
- Added support for ssl.PROTOCOL_TLSv1 from IronPython in light of the POODLE vulnerability
- Python and IronPython can be run in parallel now based on tips form https://github.com/shotgunsoftware/python-api/wiki/API-Usage-Tips#ironpython
