### PR TITLE
Ability to instantiate the API via a session id

### DIFF
--- a/shotgun_api3/__init__.py
+++ b/shotgun_api3/__init__.py
@@ -1,4 +1,4 @@
 from shotgun import (Shotgun, ShotgunError, ShotgunFileDownloadError, Fault, 
-                     ProtocolError, ResponseError, Error, __version__)
+                     SessionAuthenticationFault, ProtocolError, ResponseError, Error, __version__)
 from shotgun import SG_TIMEZONE as sg_timezone
 

--- a/shotgun_api3/__init__.py
+++ b/shotgun_api3/__init__.py
@@ -1,4 +1,4 @@
 from shotgun import (Shotgun, ShotgunError, ShotgunFileDownloadError, Fault, 
-                     SessionAuthenticationFault, ProtocolError, ResponseError, Error, __version__)
+                     AuthenticationFault, ProtocolError, ResponseError, Error, __version__)
 from shotgun import SG_TIMEZONE as sg_timezone
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1783,10 +1783,12 @@ class Shotgun(object):
 
         :raises ShotgunError: If the server response contains an exception.
         """
+ 
+        ERR_AUTH = 102 # error code for authentication related problems
 
         if isinstance(sg_response, dict) and sg_response.get("exception"):
             
-            if sg_response.get("error_code") == 102:
+            if sg_response.get("error_code") == ERR_AUTH:
                 raise AuthenticationFault(sg_response.get("message", "Unknown Authentication Error"))
 
             else:

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -381,13 +381,6 @@ class Shotgun(object):
         # call to server will only be made once and will raise error
         if connect:
             self.server_caps
-            
-        # if the connection has been established using a username/password combination,
-        # retrieve a session token from the server and then clear the password 
-        # member variable for security reasons
-        if self.config.user_password:
-            self._get_session_token()
-            self.config.user_password = None
 
     # ========================================================================
     # API Functions
@@ -1433,13 +1426,11 @@ class Shotgun(object):
         return url
 
     def authenticate_human_user(self, user_login, user_password):
-        """
-        Authenticate Shotgun HumanUser. HumanUser must be an active account.
-        
-        :param user_login: Login name of Shotgun HumanUser
-        :param user_password: Password for Shotgun HumanUser
-        :return: Dictionary of HumanUser including ID if authenticated, None is unauthorized.
-        """
+        '''Authenticate Shotgun HumanUser. HumanUser must be an active account.
+        @param user_login: Login name of Shotgun HumanUser
+        @param user_password: Password for Shotgun HumanUser
+        @return: Dictionary of HumanUser including ID if authenticated, None is unauthorized.
+        '''
         if not user_login:
             raise ValueError('Please supply a username to authenticate.')
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1500,8 +1500,8 @@ class Shotgun(object):
     def get_session_token(self):
         """
         Get the session token associated with the current session.
-        If a session token has already been established, the token for this 
-        is returned, otherwise a new one is generated on the server and returned.
+        If a session token has already been established, this is returned, 
+        otherwise a new one is generated on the server and returned.
         
         :returns: String containing a session token
         """

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -381,6 +381,13 @@ class Shotgun(object):
         # call to server will only be made once and will raise error
         if connect:
             self.server_caps
+            
+        # if the connection has been established using a username/password combination,
+        # retrieve a session token from the server and then clear the password 
+        # member variable for security reasons
+        if self.config.user_password:
+            self._get_session_token()
+            self.config.user_password = None
 
     # ========================================================================
     # API Functions
@@ -1426,11 +1433,13 @@ class Shotgun(object):
         return url
 
     def authenticate_human_user(self, user_login, user_password):
-        '''Authenticate Shotgun HumanUser. HumanUser must be an active account.
-        @param user_login: Login name of Shotgun HumanUser
-        @param user_password: Password for Shotgun HumanUser
-        @return: Dictionary of HumanUser including ID if authenticated, None is unauthorized.
-        '''
+        """
+        Authenticate Shotgun HumanUser. HumanUser must be an active account.
+        
+        :param user_login: Login name of Shotgun HumanUser
+        :param user_password: Password for Shotgun HumanUser
+        :return: Dictionary of HumanUser including ID if authenticated, None is unauthorized.
+        """
         if not user_login:
             raise ValueError('Please supply a username to authenticate.')
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -93,8 +93,8 @@ class Fault(ShotgunError):
     """Exception when server side exception detected."""
     pass
 
-class SessionAuthenticationFault(Fault):
-    """Exception when the server side reports that a session is no longer valid"""
+class AuthenticationFault(Fault):
+    """Exception when the server side reports an error related to authentication"""
     pass
 
 # ----------------------------------------------------------------------------
@@ -1786,20 +1786,9 @@ class Shotgun(object):
 
         if isinstance(sg_response, dict) and sg_response.get("exception"):
             
-            # handle the following cases explicitly
-            #
-            # {'exception': True, 
-            #  'error_code': 102, 
-            #  'message': "Can't authenticate session token 'xxxxxxxx'"}
-            #
-            # {'exception': True, 
-            #  'error_code': 102, 
-            #  'message': "Session token 'xxxxxxxx has expired'"}
-            
-            msg = sg_response.get("message")
-            
-            if msg and ("Can't authenticate session token" in msg or "has expired" in msg):
-                raise SessionAuthenticationFault(msg)
+            if sg_response.get("error_code") == 102:
+                raise AuthenticationFault(sg_response.get("message", "Unknown Authentication Error"))
+
             else:
                 # raise general Fault            
                 raise Fault(sg_response.get("message", "Unknown Error"))

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -210,6 +210,7 @@ class _Config(object):
         self.scheme = None
         self.server = None
         self.api_path = None
+        self.raw_http_proxy = None 
         self.proxy_server = None
         self.proxy_port = 8080
         self.proxy_user = None
@@ -326,6 +327,7 @@ class Shotgun(object):
         self.config.sudo_as_login = sudo_as_login
         self.config.convert_datetimes_to_utc = convert_datetimes_to_utc
         self.config.no_ssl_validation = NO_SSL_VALIDATION
+        self.config.raw_http_proxy = http_proxy
         self._connection = None
         self.__ca_certs = ca_certs
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -246,8 +246,8 @@ class Shotgun(object):
                  ca_certs=None,
                  login=None,
                  password=None,
-                 session_token=None,
-                 sudo_as_login=None):
+                 sudo_as_login=None,
+                 session_token=None):
         """Initialises a new instance of the Shotgun client.
 
         :param base_url: http or https url to the shotgun server.
@@ -281,15 +281,15 @@ class Shotgun(object):
         :param password: The password for the login to use to authenticate to
         the server. If password is provided, then login must be as well and
         neither script_name nor api_key can be provided.
-
-        :param session_token: The session token to use to authenticate to the server. This
-        can be used as an alternative to authenticating with a script user or regular user.
-        You retrieve the session token by running the generate_session_token() method.
         
         :param sudo_as_login: A user login string for the user whose permissions will
         be applied to all actions and who will be logged as the user performing
         all actions. Note that logged events will have an additional extra meta-data parameter 
         'sudo_actual_user' indicating the script or user that actually authenticated.
+        
+        :param session_token: The session token to use to authenticate to the server. This
+        can be used as an alternative to authenticating with a script user or regular user.
+        You retrieve the session token by running the generate_session_token() method.        
         """
 
         # verify authentication arguments

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1604,6 +1604,8 @@ class Shotgun(object):
         elif self.config.session_token:
             auth_params = {
                 "session_token" : str(self.config.session_token),
+                # Request server side to raise exception for expired sessions
+                "reject_if_expired": True
             }
 
         else:

--- a/tests/base.py
+++ b/tests/base.py
@@ -64,7 +64,7 @@ class TestBase(unittest.TestCase):
                              self.config.script_name,
                              self.config.api_key,
                              http_proxy=self.config.http_proxy )
-            self.session_token = sg.generate_session_token()
+            self.session_token = sg.get_session_token()
             # now log in using session token
             self.sg = api.Shotgun(self.config.server_url,
                                   session_token=self.session_token,

--- a/tests/base.py
+++ b/tests/base.py
@@ -30,6 +30,7 @@ class TestBase(unittest.TestCase):
         self.human_password = None
         self.server_url     = None
         self.server_address = None
+        self.session_token  = None
         self.connect        = False
 
 
@@ -54,6 +55,19 @@ class TestBase(unittest.TestCase):
             self.sg = api.Shotgun(self.config.server_url,
                                   login=self.human_login,
                                   password=self.human_password,
+                                  http_proxy=self.config.http_proxy,
+                                  connect=self.connect )
+        elif auth_mode == 'SessionToken':
+            # first make an instance based on script key/name so 
+            # we can generate a session token
+            sg = api.Shotgun(self.config.server_url,
+                             self.config.script_name,
+                             self.config.api_key,
+                             http_proxy=self.config.http_proxy )
+            self.session_token = sg.generate_session_token()
+            # now log in using session token
+            self.sg = api.Shotgun(self.config.server_url,
+                                  session_token=self.session_token,
                                   http_proxy=self.config.http_proxy,
                                   connect=self.connect )
         else:
@@ -258,6 +272,14 @@ class HumanUserAuthLiveTestBase(LiveTestBase):
     '''
     def setUp(self):
         super(HumanUserAuthLiveTestBase, self).setUp('HumanUser')
+
+class SessionTokenAuthLiveTestBase(LiveTestBase):
+    '''
+    Test base for relying on a Shotgun connection authenticate through the
+    configured session_token parameter.
+    '''
+    def setUp(self):
+        super(SessionTokenAuthLiveTestBase, self).setUp('SessionToken')
 
 
 class SgTestConfig(object):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1420,15 +1420,15 @@ class TestErrors(base.TestBase):
 
         # Test failed authentications
         sg = shotgun_api3.Shotgun(server_url, script_name, api_key)
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
         script_name = self.config.script_name
         api_key = 'notrealapikey'
         sg = shotgun_api3.Shotgun(server_url, script_name, api_key)
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
         sg = shotgun_api3.Shotgun(server_url, login=login, password='not a real password')
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
     @patch('shotgun_api3.shotgun.Http.request')
     def test_status_not_200(self, mock_request):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,10 +124,10 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertEqual("Page", page[0]['type'])
         self.assertEqual(datetime.datetime, type(page[0]['last_accessed']))
 
-    def test_get_session_token(self):
+    def test_generate_session_token(self):
         """Got session UUID"""
         #TODO test results
-        rv = self.sg._get_session_token()
+        rv = self.sg.generate_session_token()
         self.assertTrue(rv)
 
     def test_upload_download(self):
@@ -165,7 +165,7 @@ class TestShotgunApi(base.LiveTestBase):
         file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sg_logo_download.jpg")
         result = self.sg.download_attachment(attach_id, file_path=file_path)
         self.assertEqual(result, file_path)
-    	# On windows read may not read to end of file unless opened 'rb'
+        # On windows read may not read to end of file unless opened 'rb'
         fp = open(file_path, 'rb')
         attach_file = fp.read()
         fp.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1507,6 +1507,10 @@ class TestHumanUserSudoAuth(base.TestBase):
 
 
 class TestHumanUserAuth(base.HumanUserAuthLiveTestBase):
+    """
+    Testing the username/password authentication method
+    """
+    
     def test_humanuser_find(self):
         """Called find, find_one for known entities as human user"""
         filters = []
@@ -1528,6 +1532,63 @@ class TestHumanUserAuth(base.HumanUserAuthLiveTestBase):
 
     def test_humanuser_upload_thumbnail_for_version(self):
         """simple upload thumbnail for version test as human user."""
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.abspath(os.path.expanduser(
+            os.path.join(this_dir,"sg_logo.jpg")))
+        size = os.stat(path).st_size
+
+        # upload thumbnail
+        thumb_id = self.sg.upload_thumbnail("Version",
+            self.version['id'], path)
+        self.assertTrue(isinstance(thumb_id, int))
+
+        # check result on version
+        version_with_thumbnail = self.sg.find_one('Version',
+            [['id', 'is', self.version['id']]],
+            fields=['image'])
+
+        self.assertEqual(version_with_thumbnail.get('type'), 'Version')
+        self.assertEqual(version_with_thumbnail.get('id'), self.version['id'])
+
+
+        h = Http(".cache")
+        thumb_resp, content = h.request(version_with_thumbnail.get('image'), "GET")
+        self.assertEqual(thumb_resp['status'], '200')
+        self.assertEqual(thumb_resp['content-type'], 'image/jpeg')
+
+        # clear thumbnail
+        response_clear_thumbnail = self.sg.update("Version",
+            self.version['id'], {'image':None})
+        expected_clear_thumbnail = {'id': self.version['id'], 'image': None, 'type': 'Version'}
+        self.assertEqual(expected_clear_thumbnail, response_clear_thumbnail)
+
+
+class TestSessionTokenAuth(base.SessionTokenAuthLiveTestBase):
+    """
+    Testing the session token based authentication method
+    """
+    
+    def test_humanuser_find(self):
+        """Called find, find_one for known entities as session token based user"""
+        filters = []
+        filters.append(['project', 'is', self.project])
+        filters.append(['id', 'is', self.version['id']])
+
+        fields = ['id']
+
+        versions = self.sg.find("Version", filters, fields=fields)
+
+        self.assertTrue(isinstance(versions, list))
+        version = versions[0]
+        self.assertEqual("Version", version["type"])
+        self.assertEqual(self.version['id'], version["id"])
+
+        version = self.sg.find_one("Version", filters, fields=fields)
+        self.assertEqual("Version", version["type"])
+        self.assertEqual(self.version['id'], version["id"])
+
+    def test_humanuser_upload_thumbnail_for_version(self):
+        """simple upload thumbnail for version test as session based token user."""
         this_dir, _ = os.path.split(__file__)
         path = os.path.abspath(os.path.expanduser(
             os.path.join(this_dir,"sg_logo.jpg")))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,10 +124,10 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertEqual("Page", page[0]['type'])
         self.assertEqual(datetime.datetime, type(page[0]['last_accessed']))
 
-    def test_generate_session_token(self):
+    def test_get_session_token(self):
         """Got session UUID"""
         #TODO test results
-        rv = self.sg.generate_session_token()
+        rv = self.sg.get_session_token()
         self.assertTrue(rv)
 
     def test_upload_download(self):


### PR DESCRIPTION
Adds a constructor parameter `session_token` which makes it possible to create an API instance without either username/password or script/script key. 
A session token can be generated via the new `generate_session_token()` method. 