### PR TITLE
Ticket/28441 hide template projects by default

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -439,7 +439,7 @@ class TestShotgunApi(base.LiveTestBase):
         assert(result['groups'][0]['summaries'])
         assert(result['summaries'])
 
-    def test_summary_include_archived_projects(self):
+    def _test_summary_include_archived_projects(self):
         if self.sg.server_caps.version > (5, 3, 13):
             # archive project
             self.sg.update('Project', self.project['id'], {'archived':True})
@@ -1345,7 +1345,7 @@ class TestFind(base.LiveTestBase):
         result = self.sg.find_one( 'Asset', [['id','is',self.asset['id']],[num_field, 'is_not', None]] ,[num_field] )
         self.assertFalse(result == None)
 
-    def test_include_archived_projects(self):
+    def _test_include_archived_projects(self):
         if self.sg.server_caps.version > (5, 3, 13):
             # Ticket #25082
             result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,18 +74,18 @@ class TestShotgunClient(base.MockTestBase):
         sc = ServerCapabilities("foo", {"version" : (2,4,0)})
 
         sc.version = (2,3,99)
-        self.assertRaises(api.ShotgunError, sc._ensure_json_supported)
+        self.assertRaises(api.ShotgunError, sc.ensure_json_supported)
         self.assertRaises(api.ShotgunError, ServerCapabilities, "foo",
             {"version" : (2,2,0)})
 
         sc.version = (0,0,0)
-        self.assertRaises(api.ShotgunError, sc._ensure_json_supported)
+        self.assertRaises(api.ShotgunError, sc.ensure_json_supported)
 
         sc.version = (2,4,0)
-        sc._ensure_json_supported()
+        sc.ensure_json_supported()
 
         sc.version = (2,5,0)
-        sc._ensure_json_supported()
+        sc.ensure_json_supported()
 
 
     def test_session_uuid(self):

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,21 +1,23 @@
 """Test using the Shotgun API flags."""
 
 import shotgun_api3
+from shotgun_api3 import *
 from shotgun_api3.lib.httplib2 import Http
 
 import base
 
+import logging
+
 class TestFlags(base.LiveTestBase):
+
     def setUp(self):
         super(TestFlags, self).setUp()
+
         # We will need the created_at field for the shot
         fields = self.shot.keys()[:]
         fields.append('created_at')
         self.shot = self.sg.find_one('Shot', [['id', 'is', self.shot['id']]], fields)
-        # We will need the uuid field for our LocalStorage
-        fields = self.local_storage.keys()[:]
-        fields.append('uuid')
-        self.local_storage = self.sg.find_one('LocalStorage', [['id', 'is', self.local_storage['id']]], fields)
+
 
     def test_summary_include_archived_projects(self):
         """Test summary with 'include_archived_projects'"""
@@ -23,19 +25,12 @@ class TestFlags(base.LiveTestBase):
         if self.sg.server_caps.version > (5, 3, 13):
             # Ticket #25082 ability to hide archived projects in summary
 
-            # archive project
-            self.sg.update('Project', self.project['id'], {'archived':True})
-
             summaries = [{'field': 'id', 'type': 'count'}]
             grouping = [{'direction': 'asc', 'field': 'id', 'type': 'exact'}]
             filters = [['project', 'is', self.project]]
 
-            # setting defaults to False, so we should get result
-            result = self.sg.summarize('Shot',
-                                       filters=filters,
-                                       summary_fields=summaries,
-                                       grouping=grouping)
-            self.assertEqual(result['summaries']['id'],  1)
+            # archive project
+            self.sg.update('Project', self.project['id'], {'archived':True})
 
             # should get no result
             result = self.sg.summarize('Shot',
@@ -43,85 +38,199 @@ class TestFlags(base.LiveTestBase):
                                        summary_fields=summaries,
                                        grouping=grouping,
                                        include_archived_projects=False)
-            self.assertEqual(result['summaries']['id'],  0)
-
-            # reset project
-            self.sg.update('Project', self.project['id'], {'archived':False})
-
-    def test_summary_include_template_projects(self):
-        """Test summary with 'include_template_projects'"""
-
-        if self.sg.server_caps.version > (6, 0, 0):
-            # Ticket #28441
-
-            # set as template project
-            self.sg.update('Project', self.project['id'], {'template':True})
-
-            summaries = [{'field': 'id', 'type': 'count'}]
-            grouping = [{'direction': 'asc', 'field': 'id', 'type': 'exact'}]
-            filters = [['project', 'is', self.project]]
-
-            # setting defaults to False, so we should get no result
-            result = self.sg.summarize('Shot',
-                                       filters=filters,
-                                       summary_fields=summaries,
-                                       grouping=grouping)
-            self.assertEqual(result['summaries']['id'],  0)
+            self.assertEquals(result['summaries']['id'], 0)
 
             # should get result
             result = self.sg.summarize('Shot',
                                        filters=filters,
                                        summary_fields=summaries,
                                        grouping=grouping,
-                                       include_template_projects=False)
-            self.assertEqual(result['summaries']['id'],  1)
+                                       include_archived_projects=True)
+            self.assertEquals(result['summaries']['id'], 1)
 
-            # reset project
-            self.sg.update('Project', self.project['id'], {'template':False})
-
-    def test_include_archived_projects(self):
-        """Test find with 'include_archived_projects'"""
-
-        if self.sg.server_caps.version > (5, 3, 13):
-            # Ticket #25082
-
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
-            self.assertEquals(self.shot['id'], result['id'])
-
-            # archive project 
-            self.sg.update('Project', self.project['id'], {'archived':True})
-
-            # setting defaults to True, so we should get result
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
-            self.assertEquals(self.shot['id'], result['id'])
-
-            # should get no result
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]], include_archived_projects=False)
-            self.assertEquals(None, result)
+            # setting defaults to True, should get result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping)
+            self.assertEquals(result['summaries']['id'], 1)
 
             # reset project
             self.sg.update('Project', self.project['id'], {'archived':False})
 
-    def test_include_template_projects(self):
-        """Test find with 'include_template_projects'"""
 
-        if self.sg.server_caps.version > (6, 0, 0):
-            # Ticket #28441
+    def test_summary_include_template_projects(self):
+        """Test summary with 'include_template_projects'"""
 
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
-            self.assertEquals(self.shot['id'], result['id'])
+        # Ticket #28441
 
-            # set as template project 
+        self.LOG.setLevel(logging.DEBUG)
+
+        summaries = [{'field': 'id', 'type': 'count'}]
+        grouping = [{'direction': 'asc', 'field': 'id', 'type': 'exact'}]
+        filters = [['project', 'is', self.project]]
+
+        # control
+        result = self.sg.summarize('Shot',
+                                   filters=filters,
+                                   summary_fields=summaries,
+                                   grouping=grouping)
+        self.assertEquals(result['summaries']['id'], 1)
+
+        # backwards-compatibility
+        if self.sg.server_caps.version < (6, 0, 0):
+
+            # flag should not be passed, should get result
+            self.assertRaises(ShotgunError, self.sg.summarize, 'Shot',
+                              filters=filters,
+                              summary_fields=summaries,
+                              grouping=grouping,
+                              include_template_projects=True)
+
+        # test new features
+        if self.sg.server_caps.version >= (6, 0, 0):
+            # set as template project
             self.sg.update('Project', self.project['id'], {'is_template':True})
 
-            # setting defaults to False, so we should not get result
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
-            self.assertEquals(None, result)
-
             # should get result
-            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]], include_template_projects=True)
-            self.assertEquals(self.shot['id'], result['id'])
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping,
+                                       include_template_projects=True)
+            self.assertEquals(result['summaries']['id'],  1)
+
+            # should get no result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping,
+                                       include_template_projects=False)
+            self.assertEquals(result['summaries']['id'], 0)
+
+            # setting defaults to False, should get no result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping)
+            self.assertEquals(result['summaries']['id'], 0)
 
             # reset project
             self.sg.update('Project', self.project['id'], {'is_template':False})
 
+        self.LOG.setLevel(logging.WARN)
+
+
+    def test_include_archived_projects(self):
+        """Test find with 'include_archived_projects'"""
+
+        # Ticket #25082
+
+        filters = [['id', 'is', self.shot['id']]]
+
+        if self.sg.server_caps.version > (5, 3, 13):
+
+            # control
+            result = self.sg.find_one('Shot',
+                                      filters=filters)
+            self.assertEquals(result['id'], self.shot['id'])
+
+            # archive project 
+            self.sg.update('Project', self.project['id'], {'archived':True})
+
+            # should get no result
+            result = self.sg.find_one('Shot',
+                                      filters=filters,
+                                      include_archived_projects=False)
+            self.assertEquals(result, None)
+
+            # should get result
+            result = self.sg.find_one('Shot',
+                                      filters=filters,
+                                      include_archived_projects=True)
+            self.assertEquals(result['id'], self.shot['id'])
+
+            # setting defaults to True, should get result
+            result = self.sg.find_one('Shot',
+                                      filters=filters)
+            self.assertEquals(result['id'], self.shot['id'])
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'archived':False})
+
+
+    def test_include_template_projects(self):
+        """Test find with 'include_template_projects'"""
+
+        # Ticket #28441
+
+        self.LOG.setLevel(logging.DEBUG)
+
+        filters = [['id', 'is', self.shot['id']]]
+
+        # control
+        result = self.sg.find_one('Shot',
+                          filters=filters)
+        self.assertEquals(result['id'], self.shot['id'])
+
+        # backwards-compatibility
+        if self.sg.server_caps.version < (6, 0, 0):
+
+            self.assertRaises(ShotgunError, self.sg.find_one, 'Shot',
+                              filters=filters,
+                              include_template_projects=True)
+
+        # test new features
+        if self.sg.server_caps.version >= (6, 0, 0):
+
+            # set as template project 
+            self.sg.update('Project', self.project['id'], {'is_template':True})
+
+            # should get result
+            result = self.sg.find_one('Shot',
+                                      filters=filters,
+                                      include_template_projects=True)
+            self.assertEquals(result['id'], self.shot['id'])
+
+            # should get no result
+            result = self.sg.find_one('Shot',
+                                      filters=filters,
+                                      include_template_projects=False)
+            self.assertEquals(result, None)
+
+            # setting defaults to False, should get no result
+            result = self.sg.find_one('Shot',
+                                      filters=filters)
+            self.assertEquals(result, None)
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'is_template':False})
+
+        self.LOG.setLevel(logging.WARN)
+
+
+    def test_find_template_project(self):
+        """Test find the 'Template Project'"""
+
+        # Ticket #28441
+
+        if self.sg.server_caps.version >= (6, 0, 0):
+
+            # find by name
+            result = self.sg.find_one('Project', [['name', 'is', self.template_project['name']]])
+            self.assertEquals(result['id'], self.template_project['id'])
+
+            # find by ID
+            result = self.sg.find_one('Project', [['id', 'is', self.template_project['id']]])
+            self.assertEquals(result['id'], self.template_project['id'])
+
+            # find attached entity
+            result = self.sg.find_one(
+                'Ticket',
+                [
+                    ['id', 'is', self.template_ticket['id']],
+                    ['project.Project.name', 'is', 'Template Project'],
+                    ['project.Project.layout_project', 'is', None]
+                ]
+            )
+            self.assertEquals(result['id'], self.template_ticket['id'])

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,127 @@
+"""Test using the Shotgun API flags."""
+
+import shotgun_api3
+from shotgun_api3.lib.httplib2 import Http
+
+import base
+
+class TestFlags(base.LiveTestBase):
+    def setUp(self):
+        super(TestFlags, self).setUp()
+        # We will need the created_at field for the shot
+        fields = self.shot.keys()[:]
+        fields.append('created_at')
+        self.shot = self.sg.find_one('Shot', [['id', 'is', self.shot['id']]], fields)
+        # We will need the uuid field for our LocalStorage
+        fields = self.local_storage.keys()[:]
+        fields.append('uuid')
+        self.local_storage = self.sg.find_one('LocalStorage', [['id', 'is', self.local_storage['id']]], fields)
+
+    def test_summary_include_archived_projects(self):
+        """Test summary with 'include_archived_projects'"""
+
+        if self.sg.server_caps.version > (5, 3, 13):
+            # Ticket #25082 ability to hide archived projects in summary
+
+            # archive project
+            self.sg.update('Project', self.project['id'], {'archived':True})
+
+            summaries = [{'field': 'id', 'type': 'count'}]
+            grouping = [{'direction': 'asc', 'field': 'id', 'type': 'exact'}]
+            filters = [['project', 'is', self.project]]
+
+            # setting defaults to False, so we should get result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping)
+            self.assertEqual(result['summaries']['id'],  1)
+
+            # should get no result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping,
+                                       include_archived_projects=False)
+            self.assertEqual(result['summaries']['id'],  0)
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'archived':False})
+
+    def test_summary_include_template_projects(self):
+        """Test summary with 'include_template_projects'"""
+
+        if self.sg.server_caps.version > (6, 0, 0):
+            # Ticket #28441
+
+            # set as template project
+            self.sg.update('Project', self.project['id'], {'template':True})
+
+            summaries = [{'field': 'id', 'type': 'count'}]
+            grouping = [{'direction': 'asc', 'field': 'id', 'type': 'exact'}]
+            filters = [['project', 'is', self.project]]
+
+            # setting defaults to False, so we should get no result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping)
+            self.assertEqual(result['summaries']['id'],  0)
+
+            # should get result
+            result = self.sg.summarize('Shot',
+                                       filters=filters,
+                                       summary_fields=summaries,
+                                       grouping=grouping,
+                                       include_template_projects=False)
+            self.assertEqual(result['summaries']['id'],  1)
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'template':False})
+
+    def test_include_archived_projects(self):
+        """Test find with 'include_archived_projects'"""
+
+        if self.sg.server_caps.version > (5, 3, 13):
+            # Ticket #25082
+
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
+            self.assertEquals(self.shot['id'], result['id'])
+
+            # archive project 
+            self.sg.update('Project', self.project['id'], {'archived':True})
+
+            # setting defaults to True, so we should get result
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
+            self.assertEquals(self.shot['id'], result['id'])
+
+            # should get no result
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]], include_archived_projects=False)
+            self.assertEquals(None, result)
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'archived':False})
+
+    def test_include_template_projects(self):
+        """Test find with 'include_template_projects'"""
+
+        if self.sg.server_caps.version > (6, 0, 0):
+            # Ticket #28441
+
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
+            self.assertEquals(self.shot['id'], result['id'])
+
+            # set as template project 
+            self.sg.update('Project', self.project['id'], {'is_template':True})
+
+            # setting defaults to False, so we should not get result
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]])
+            self.assertEquals(None, result)
+
+            # should get result
+            result = self.sg.find_one('Shot', [['id','is',self.shot['id']]], include_template_projects=True)
+            self.assertEquals(self.shot['id'], result['id'])
+
+            # reset project
+            self.sg.update('Project', self.project['id'], {'is_template':False})
+


### PR DESCRIPTION
We're adding `Project.is_template` in v6.0.0 to support multiple template projects. Unlike `include_archived_projects` (which defaults to `True`), the new `include_template_projects` CRUD flag defaults to `False`.
- I did some refactoring as I felt dirty copy/pasting `ensure_include_archived_projects` 
- The rest is IF statements copied from existing `include_archived_flag` support w/ the logic reversed
- Moved the flag tests into their own file, to avoid needing to run the gargantuan `test_api.py`
