### PR TITLE
Toolkit security changes

### DIFF
--- a/shotgun_api3/__init__.py
+++ b/shotgun_api3/__init__.py
@@ -1,4 +1,4 @@
 from shotgun import (Shotgun, ShotgunError, ShotgunFileDownloadError, Fault, 
-                     ProtocolError, ResponseError, Error, __version__)
+                     AuthenticationFault, ProtocolError, ResponseError, Error, __version__)
 from shotgun import SG_TIMEZONE as sg_timezone
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -63,6 +63,7 @@ mimetypes.add_type('video/mp4', '.mp4')  # from some OS/distros
 LOG = logging.getLogger("shotgun_api3")
 LOG.setLevel(logging.WARN)
 
+
 SG_TIMEZONE = SgTimezone()
 
 
@@ -90,6 +91,10 @@ class ShotgunFileDownloadError(ShotgunError):
 
 class Fault(ShotgunError):
     """Exception when server side exception detected."""
+    pass
+
+class AuthenticationFault(Fault):
+    """Exception when the server side reports an error related to authentication"""
     pass
 
 # ----------------------------------------------------------------------------
@@ -209,6 +214,11 @@ class _Config(object):
         self.scheme = None
         self.server = None
         self.api_path = None
+        # The raw_http_proxy reflects the exact string passed in 
+        # to the Shotgun constructor. This can be useful if you 
+        # need to construct a Shotgun API instance based on 
+        # another Shotgun API instance.
+        self.raw_http_proxy = None 
         self.proxy_server = None
         self.proxy_port = 8080
         self.proxy_user = None
@@ -237,10 +247,11 @@ class Shotgun(object):
                  http_proxy=None,
                  ensure_ascii=True,
                  connect=True,
-				 ca_certs=None,
+                 ca_certs=None,
                  login=None,
                  password=None,
-                 sudo_as_login=None):
+                 sudo_as_login=None,
+                 session_token=None):
         """Initialises a new instance of the Shotgun client.
 
         :param base_url: http or https url to the shotgun server.
@@ -263,9 +274,9 @@ class Shotgun(object):
         form [username:pass@]proxy.com[:8080]
 
         :param connect: If True, connect to the server. Only used for testing.
-		
-		:param ca_certs: The path to the SSL certificate file. Useful for users
-		who would like to package their application into an executable.
+        
+        :param ca_certs: The path to the SSL certificate file. Useful for users
+        who would like to package their application into an executable.
 
         :param login: The login to use to authenticate to the server. If login
         is provided, then password must be as well and neither script_name nor
@@ -279,9 +290,21 @@ class Shotgun(object):
         be applied to all actions and who will be logged as the user performing
         all actions. Note that logged events will have an additional extra meta-data parameter 
         'sudo_actual_user' indicating the script or user that actually authenticated.
+        
+        :param session_token: The session token to use to authenticate to the server. This
+        can be used as an alternative to authenticating with a script user or regular user.
+        You retrieve the session token by running the get_session_token() method.        
         """
 
         # verify authentication arguments
+        if session_token is not None:
+            if script_name is not None or api_key is not None:
+                raise ValueError("cannot provide both session_token "
+                                 "and script_name/api_key")
+            if login is not None or password is not None:
+                raise ValueError("cannot provide both session_token "
+                                 "and login/password")
+        
         if login is not None or password is not None:
             if script_name is not None or api_key is not None:
                 raise ValueError("cannot provide both login/password "
@@ -298,19 +321,20 @@ class Shotgun(object):
                 raise ValueError("script_name provided without api_key")
 
         # Can't use 'all' with python 2.4
-        if len([x for x in [script_name, api_key, login, password] if x]) == 0:
+        if len([x for x in [session_token, script_name, api_key, login, password] if x]) == 0:
             if connect:
-                raise ValueError("must provide either login/password "
-                                 "or script_name/api_key")
+                raise ValueError("must provide login/password, session_token or script_name/api_key")
 
         self.config = _Config()
         self.config.api_key = api_key
         self.config.script_name = script_name
         self.config.user_login = login
         self.config.user_password = password
+        self.config.session_token = session_token
         self.config.sudo_as_login = sudo_as_login
         self.config.convert_datetimes_to_utc = convert_datetimes_to_utc
         self.config.no_ssl_validation = NO_SSL_VALIDATION
+        self.config.raw_http_proxy = http_proxy
         self._connection = None
         self.__ca_certs = ca_certs
 
@@ -1359,7 +1383,7 @@ class Shotgun(object):
         """Sets up urllib2 with a cookie for authentication on the Shotgun 
         instance.
         """
-        sid = self._get_session_token()
+        sid = self.get_session_token()
         cj = cookielib.LWPCookieJar()
         c = cookielib.Cookie('0', '_session_id', sid, None, False,
             self.config.server, False, False, "/", True, False, None, True,
@@ -1473,10 +1497,13 @@ class Shotgun(object):
         record = self._call_rpc("update_project_last_accessed_by_current_user", params)
         result = self._parse_records(record)[0]
 
-
-    def _get_session_token(self):
-        """Hack to authenticate in order to download protected content
-        like Attachments
+    def get_session_token(self):
+        """
+        Get the session token associated with the current session.
+        If a session token has already been established, this is returned, 
+        otherwise a new one is generated on the server and returned.
+        
+        :returns: String containing a session token
         """
         if self.config.session_token:
             return self.config.session_token
@@ -1485,9 +1512,8 @@ class Shotgun(object):
         session_token = (rv or {}).get("session_id")
         if not session_token:
             raise RuntimeError("Could not extract session_id from %s", rv)
-
-        self.config.session_token = session_token
-        return self.config.session_token
+        self.config.session_token = session_token 
+        return session_token
 
     def _build_opener(self, handler):
         """Build urllib2 opener with appropriate proxy handler."""
@@ -1559,6 +1585,7 @@ class Shotgun(object):
 
     def _auth_params(self):
         """ return a dictionary of the authentication parameters being used. """
+                
         # Used to authenticate HumanUser credentials
         if self.config.user_login and self.config.user_password:
             auth_params = {
@@ -1571,6 +1598,14 @@ class Shotgun(object):
             auth_params = {
                 "script_name" : str(self.config.script_name),
                 "script_key" : str(self.config.api_key),
+            }
+
+        # Authenticate using session_id
+        elif self.config.session_token:
+            auth_params = {
+                "session_token" : str(self.config.session_token),
+                # Request server side to raise exception for expired sessions
+                "reject_if_expired": True
             }
 
         else:
@@ -1750,10 +1785,17 @@ class Shotgun(object):
 
         :raises ShotgunError: If the server response contains an exception.
         """
+ 
+        ERR_AUTH = 102 # error code for authentication related problems
 
         if isinstance(sg_response, dict) and sg_response.get("exception"):
-            raise Fault(sg_response.get("message",
-                "Unknown Error"))
+            
+            if sg_response.get("error_code") == ERR_AUTH:
+                raise AuthenticationFault(sg_response.get("message", "Unknown Authentication Error"))
+
+            else:
+                # raise general Fault            
+                raise Fault(sg_response.get("message", "Unknown Error"))
         return
 
     def _visit_data(self, data, visitor):

--- a/tests/base.py
+++ b/tests/base.py
@@ -30,6 +30,7 @@ class TestBase(unittest.TestCase):
         self.human_password = None
         self.server_url     = None
         self.server_address = None
+        self.session_token  = None
         self.connect        = False
 
 
@@ -54,6 +55,19 @@ class TestBase(unittest.TestCase):
             self.sg = api.Shotgun(self.config.server_url,
                                   login=self.human_login,
                                   password=self.human_password,
+                                  http_proxy=self.config.http_proxy,
+                                  connect=self.connect )
+        elif auth_mode == 'SessionToken':
+            # first make an instance based on script key/name so 
+            # we can generate a session token
+            sg = api.Shotgun(self.config.server_url,
+                             self.config.script_name,
+                             self.config.api_key,
+                             http_proxy=self.config.http_proxy )
+            self.session_token = sg.get_session_token()
+            # now log in using session token
+            self.sg = api.Shotgun(self.config.server_url,
+                                  session_token=self.session_token,
                                   http_proxy=self.config.http_proxy,
                                   connect=self.connect )
         else:
@@ -258,6 +272,14 @@ class HumanUserAuthLiveTestBase(LiveTestBase):
     '''
     def setUp(self):
         super(HumanUserAuthLiveTestBase, self).setUp('HumanUser')
+
+class SessionTokenAuthLiveTestBase(LiveTestBase):
+    '''
+    Test base for relying on a Shotgun connection authenticate through the
+    configured session_token parameter.
+    '''
+    def setUp(self):
+        super(SessionTokenAuthLiveTestBase, self).setUp('SessionToken')
 
 
 class SgTestConfig(object):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,7 +127,7 @@ class TestShotgunApi(base.LiveTestBase):
     def test_get_session_token(self):
         """Got session UUID"""
         #TODO test results
-        rv = self.sg._get_session_token()
+        rv = self.sg.get_session_token()
         self.assertTrue(rv)
 
     def test_upload_download(self):
@@ -165,7 +165,7 @@ class TestShotgunApi(base.LiveTestBase):
         file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sg_logo_download.jpg")
         result = self.sg.download_attachment(attach_id, file_path=file_path)
         self.assertEqual(result, file_path)
-    	# On windows read may not read to end of file unless opened 'rb'
+        # On windows read may not read to end of file unless opened 'rb'
         fp = open(file_path, 'rb')
         attach_file = fp.read()
         fp.close()
@@ -1420,15 +1420,15 @@ class TestErrors(base.TestBase):
 
         # Test failed authentications
         sg = shotgun_api3.Shotgun(server_url, script_name, api_key)
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
         script_name = self.config.script_name
         api_key = 'notrealapikey'
         sg = shotgun_api3.Shotgun(server_url, script_name, api_key)
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
         sg = shotgun_api3.Shotgun(server_url, login=login, password='not a real password')
-        self.assertRaises(shotgun_api3.Fault, sg.find_one, 'Shot',[])
+        self.assertRaises(shotgun_api3.AuthenticationFault, sg.find_one, 'Shot',[])
 
     @patch('shotgun_api3.shotgun.Http.request')
     def test_status_not_200(self, mock_request):
@@ -1507,6 +1507,10 @@ class TestHumanUserSudoAuth(base.TestBase):
 
 
 class TestHumanUserAuth(base.HumanUserAuthLiveTestBase):
+    """
+    Testing the username/password authentication method
+    """
+    
     def test_humanuser_find(self):
         """Called find, find_one for known entities as human user"""
         filters = []
@@ -1528,6 +1532,63 @@ class TestHumanUserAuth(base.HumanUserAuthLiveTestBase):
 
     def test_humanuser_upload_thumbnail_for_version(self):
         """simple upload thumbnail for version test as human user."""
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.abspath(os.path.expanduser(
+            os.path.join(this_dir,"sg_logo.jpg")))
+        size = os.stat(path).st_size
+
+        # upload thumbnail
+        thumb_id = self.sg.upload_thumbnail("Version",
+            self.version['id'], path)
+        self.assertTrue(isinstance(thumb_id, int))
+
+        # check result on version
+        version_with_thumbnail = self.sg.find_one('Version',
+            [['id', 'is', self.version['id']]],
+            fields=['image'])
+
+        self.assertEqual(version_with_thumbnail.get('type'), 'Version')
+        self.assertEqual(version_with_thumbnail.get('id'), self.version['id'])
+
+
+        h = Http(".cache")
+        thumb_resp, content = h.request(version_with_thumbnail.get('image'), "GET")
+        self.assertEqual(thumb_resp['status'], '200')
+        self.assertEqual(thumb_resp['content-type'], 'image/jpeg')
+
+        # clear thumbnail
+        response_clear_thumbnail = self.sg.update("Version",
+            self.version['id'], {'image':None})
+        expected_clear_thumbnail = {'id': self.version['id'], 'image': None, 'type': 'Version'}
+        self.assertEqual(expected_clear_thumbnail, response_clear_thumbnail)
+
+
+class TestSessionTokenAuth(base.SessionTokenAuthLiveTestBase):
+    """
+    Testing the session token based authentication method
+    """
+    
+    def test_humanuser_find(self):
+        """Called find, find_one for known entities as session token based user"""
+        filters = []
+        filters.append(['project', 'is', self.project])
+        filters.append(['id', 'is', self.version['id']])
+
+        fields = ['id']
+
+        versions = self.sg.find("Version", filters, fields=fields)
+
+        self.assertTrue(isinstance(versions, list))
+        version = versions[0]
+        self.assertEqual("Version", version["type"])
+        self.assertEqual(self.version['id'], version["id"])
+
+        version = self.sg.find_one("Version", filters, fields=fields)
+        self.assertEqual("Version", version["type"])
+        self.assertEqual(self.version['id'], version["id"])
+
+    def test_humanuser_upload_thumbnail_for_version(self):
+        """simple upload thumbnail for version test as session based token user."""
         this_dir, _ = os.path.split(__file__)
         path = os.path.abspath(os.path.expanduser(
             os.path.join(this_dir,"sg_logo.jpg")))


### PR DESCRIPTION
We have been running the toolkit security project against this branch now for a while. It contains a couple of different changes related to security (mostly from #77, already code reviewed) and other things and I think it's ready to go into master. Here's a summary of the changes:

- Ability to create a sg api from a session token. This allows a user to instantiate a shotgun API given a session token produced by the `sg.get_session_token()` method.
- Added a `sg.get_session_token()` to generate session tokens
- Added a new `AuthenticationFault` exception type (deriving from `Fault` and backwards compatible) to indicate when a connection fails due to authentication.
- In the interest of API symmetry, added `sg.config.raw_http_proxy` which contains the same raw proxy string that is passed into the API constructor. This is handy if you need to create an sg API instance based on an existing instance, and want to make sure that the same proxy settings are used.
- To make it easy to set up your own httplib2 based connection to Shotgun (sometimes useful), added an `sg.config.proxy_handler` which represents the proxy handler that is used by Shotgun when it connects via httplib2. 

