### PR TITLE
#28822 ensure we don't try and sort by pivot_column fields by accident

### DIFF
--- a/tests/test_api_long.py
+++ b/tests/test_api_long.py
@@ -28,8 +28,15 @@ class TestShotgunApiLong(base.LiveTestBase):
                 continue
 
             # trying to use some different code paths to the other find test
+            # pivot_column fields aren't valid for sorting so ensure we're 
+            # not using one.
+            order_field = None
+            for field_name, field in fields.iteritems():
+                if field['data_type']["value"] != 'pivot_column':
+                    order_field = field_name
+                    break       
             # TODO for our test project, we haven't populated these entities....
-            order = [{'field_name': fields.keys()[0], 'direction': direction}]
+            order = [{'field_name': order_field, 'direction': direction}]
             if "project" in fields:
                 filters = [['project', 'is', self.project]]
             else:


### PR DESCRIPTION
`pivot_column` fields aren't sortable so in the case where we're sorting by an arbitrary field, ensure it's not a `pivot_column`. Iterate though the field list until we reach one that works.