### PR TITLE
#30015 New API methods for search, activity stream and note thread access

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2277,7 +2277,6 @@ class Shotgun(object):
         def _inbound_visitor(value):
             if isinstance(value, basestring):
                 if len(value) == 20 and self._DATE_TIME_PATTERN.match(value):
-                    print "time value: '%s'" % value
                     try:
                         # strptime was not on datetime in python2.4
                         value = datetime.datetime(

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1632,7 +1632,7 @@ class Shotgun(object):
             [{'content': 'Please add more awesomeness to the color grading.',
               'created_at': '2015-07-14 21:33:28 UTC',
               'created_by': {'id': 38,
-                             'name': 'John Smith',
+                             'name': 'John Pink',
                              'status': 'act',
                              'type': 'HumanUser',
                              'valid': 'valid'},

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1624,10 +1624,9 @@ class Shotgun(object):
 
 
 
-    def threaded_entity_read(self, entity_type, entity_id, entity_fields=None):
-        """Returns the full conversation for a given threaded entity, including 
-        replies and attachments. Threaded entities are for example notes
-        and tickets. 
+    def note_thread_read(self, note_id, entity_fields=None):
+        """Returns the full conversation for a given note, including 
+        replies and attachments.
         
         Returns a complex data structure on the following form:
         
@@ -1676,8 +1675,7 @@ class Shotgun(object):
                             "image"]
             }
         
-        :param entity_id: The type of threaded entity to be retrieved
-        :param entity_id: The id for the threaded entity to be retrieved
+        :param note_id: The id for the note to be retrieved
         :param entity_fields: Additional fields to retrieve as part 
                               of the request. See above for details.
                               
@@ -1688,16 +1686,12 @@ class Shotgun(object):
                 raise ShotgunError("note_thread requires server version 6.2.0 or "\
                     "higher, server is %s" % (self.server_caps.version,))
 
-        if entity_type != "Note":
-            raise ShotgunError("threaded_entity_read() currently only supports "
-                               "notes.")
-
         entity_fields = entity_fields or {}
         
         if not isinstance(entity_fields, dict):
             raise ValueError("entity_fields parameter must be a dictionary")
         
-        params = { "note_id": entity_id, "entity_fields": entity_fields }
+        params = { "note_id": note_id, "entity_fields": entity_fields }
 
         record = self._call_rpc("note_thread_contents", params)
         result = self._parse_records(record)

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1625,9 +1625,8 @@ class Shotgun(object):
 
 
 
-    def note_thread(self, note_id, entity_fields=None):
-        """
-        Returns the full conversation for a given note, including 
+    def note_thread_read(self, note_id, entity_fields=None):
+        """Returns the full conversation for a given note, including 
         replies and attachments. Returns a complex data structure
         on the following form:
         
@@ -1699,7 +1698,7 @@ class Shotgun(object):
         return result
 
 
-    def auto_complete(self, text, entity_types, project_ids=None, limit=None):
+    def global_search(self, text, entity_types, project_ids=None, limit=None):
         """
         Searches across selected entity types for a string keyword or phrase.
         
@@ -1808,8 +1807,8 @@ class Shotgun(object):
         return result
 
 
-    def activity_stream(self, entity_type, entity_id, entity_fields=None, 
-                        min_id=None, max_id=None, limit=None):
+    def activity_stream_read(self, entity_type, entity_id, entity_fields=None, 
+                             min_id=None, max_id=None, limit=None):
         """
         Retrieves activity stream data from Shotgun.
         This data corresponds to the data that is displayed on the 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1627,23 +1627,66 @@ class Shotgun(object):
 
     def note_thread(self, note_id, entity_fields=None):
         """
-        # args = {
-          #    note_id - the id of the note thread you want the contents of                        # Required
-          #    entity_fields - Dictionary of specific fields to retrieve for different entity types. In the format
-          #    { <entity_type> : [ array of fields ], <entity_type> : [ array of fields ], ... }   # Optional
-          # }
+        Returns the full conversation for a note, including replies and attachments:
+        
+            [{'content': 'Please add more awesomeness to the color grading.',
+              'created_at': '2015-07-14 21:33:28 UTC',
+              'created_by': {'id': 38,
+                             'name': 'John Smith',
+                             'status': 'act',
+                             'type': 'HumanUser',
+                             'valid': 'valid'},
+              'id': 6013,
+              'type': 'Note'},
+             {'created_at': '2015-07-14 21:33:32 UTC',
+              'created_by': {'id': 38,
+                             'name': 'John Pink',
+                             'status': 'act',
+                             'type': 'HumanUser',
+                             'valid': 'valid'},
+              'id': 159,
+              'type': 'Attachment'},
+             {'content': 'More awesomeness added',
+              'created_at': '2015-07-14 21:54:51 UTC',
+              'id': 5,
+              'type': 'Reply',
+              'user': {'id': 38,
+                       'name': 'David Blue',
+                       'status': 'act',
+                       'type': 'HumanUser',
+                       'valid': 'valid'}}]
+
+        The list is returned in descneding chronological order.
+        
+        If you wish to include additional fields beyond the ones that are 
+        returned by default, you can specify these in an entity_fields 
+        dictionary. This dictonary should be keyed by entity type and each
+        key should contain a list of fields to retrieve, for example:
+        
+            { "Note": ["created_by.HumanUser.image", 
+                      "addressings_to", 
+                      "playlist", 
+                      "user" ],
+              "Reply": ["content"], 
+              "Attachment": ["filmstrip_image", 
+                            "local_storage", 
+                            "this_file", 
+                            "image"]
+            }
+        
+        :param note_id: The id for the note to be retrieved
+        :param entity_fields: Additional fields to retrieve as part of the request. 
+                              See above for details.
+        :returns: Complex data structure 
         """        
 
         if self.server_caps.version and self.server_caps.version < (6, 2, 0):
-                raise ShotgunError("activity_stream requires server version 6.2.0 or "\
+                raise ShotgunError("note_thread requires server version 6.2.0 or "\
                     "higher, server is %s" % (self.server_caps.version,))
 
-        
         entity_fields = entity_fields or {}
-
         params = { "note_id": note_id, "entity_fields": entity_fields }
 
-        print params
         record = self._call_rpc("note_thread_contents", params)
         result = self._parse_records(record)
         return result

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
  -----------------------------------------------------------------------------
  Copyright (c) 2009-2015, Shotgun Software Inc
 
@@ -27,7 +27,7 @@
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-'''
+"""
 
 
 import base64
@@ -1550,7 +1550,7 @@ class Shotgun(object):
         return url
 
     def authenticate_human_user(self, user_login, user_password, auth_token=None):
-        '''Authenticate Shotgun HumanUser. HumanUser must be an active account.
+        """Authenticate Shotgun HumanUser. HumanUser must be an active account.
         :param user_login: Login name of Shotgun HumanUser
 
         :param user_password: Password for Shotgun HumanUser
@@ -1560,7 +1560,6 @@ class Shotgun(object):
 
         :return: Dictionary of HumanUser including ID if authenticated, None if unauthorized.
         """
-        '''
         if not user_login:
             raise ValueError('Please supply a username to authenticate.')
 
@@ -1625,10 +1624,12 @@ class Shotgun(object):
 
 
 
-    def note_thread_read(self, note_id, entity_fields=None):
-        """Returns the full conversation for a given note, including 
-        replies and attachments. Returns a complex data structure
-        on the following form:
+    def threaded_entity_read(self, entity_type, entity_id, entity_fields=None):
+        """Returns the full conversation for a given threaded entity, including 
+        replies and attachments. Threaded entities are for example notes
+        and tickets. 
+        
+        Returns a complex data structure on the following form:
         
             [{'content': 'Please add more awesomeness to the color grading.',
               'created_at': '2015-07-14 21:33:28 UTC',
@@ -1675,7 +1676,8 @@ class Shotgun(object):
                             "image"]
             }
         
-        :param note_id: The entity id for the note to be retrieved
+        :param entity_id: The type of threaded entity to be retrieved
+        :param entity_id: The id for the threaded entity to be retrieved
         :param entity_fields: Additional fields to retrieve as part 
                               of the request. See above for details.
                               
@@ -1686,21 +1688,25 @@ class Shotgun(object):
                 raise ShotgunError("note_thread requires server version 6.2.0 or "\
                     "higher, server is %s" % (self.server_caps.version,))
 
+        if entity_type != "Note":
+            raise ShotgunError("threaded_entity_read() currently only supports "
+                               "notes.")
+
         entity_fields = entity_fields or {}
         
         if not isinstance(entity_fields, dict):
             raise ValueError("entity_fields parameter must be a dictionary")
         
-        params = { "note_id": note_id, "entity_fields": entity_fields }
+        params = { "note_id": entity_id, "entity_fields": entity_fields }
 
         record = self._call_rpc("note_thread_contents", params)
         result = self._parse_records(record)
         return result
 
 
-    def global_search(self, text, entity_types, project_ids=None, limit=None):
+    def text_search(self, text, entity_types, project_ids=None, limit=None):
         """
-        Searches across selected entity types for a string keyword or phrase.
+        Searches across selected entity types for a given text.
         
         This method can be used to implement auto completion or a Shotgun 
         global search. The method requires a text input phrase that is at least 
@@ -2150,7 +2156,7 @@ class Shotgun(object):
         return json.loads(body)
 
     def _json_loads_ascii(self, body):
-        '''See http://stackoverflow.com/questions/956867'''
+        """"See http://stackoverflow.com/questions/956867"""
         def _decode_list(lst):
             newlist = []
             for i in lst:
@@ -2486,8 +2492,8 @@ class FormPostHandler(urllib2.BaseHandler):
 
 
 def _translate_filters(filters, filter_operator):
-    '''_translate_filters translates filters params into data structure
-    expected by rpc call.'''
+    """_translate_filters translates filters params into data structure
+    expected by rpc call."""
     wrapped_filters = {
         "filter_operator": filter_operator or "all",
         "filters": filters

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ import os
 import re
 from mock import patch, Mock, MagicMock
 import time
+import uuid
 import unittest
 import urlparse
 
@@ -1696,6 +1697,320 @@ class TestProjectLastAccessedByCurrentUser(base.LiveTestBase):
         # it's possible initial is None
         if initial:
             assert(initial['last_accessed_by_current_user'] < current['last_accessed_by_current_user'])
+
+
+class TestActivityStream(base.LiveTestBase):
+    """
+    Unit tests for the activity_stream_read() method
+    """
+     
+    def setUp(self):
+        super(TestActivityStream, self).setUp()
+        self._prefix = uuid.uuid4().hex 
+
+        self._shot = self.sg.create("Shot", {"code": "%s activity stream test" % self._prefix, 
+                                             "project": self.project})
+        
+        self._note = self.sg.create("Note", {"content": "Test!", 
+                                             "project": self.project, 
+                                             "note_links": [self._shot]})
+
+    def test_simple(self):
+        """
+        Test activity stream
+        """
+         
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+ 
+        result = self.sg.activity_stream_read(self._shot["type"], 
+                                              self._shot["id"])
+        
+        expected_keys = ["earliest_update_id", 
+                         "entity_id",
+                         "entity_type",
+                         "latest_update_id",
+                         "updates"]
+
+        self.assertEqual(set(expected_keys), set(result.keys()))
+        self.assertEqual(len(result["updates"]), 2)
+        self.assertEqual(result["entity_type"], "Shot")
+        self.assertEqual(result["entity_id"], self._shot["id"])
+ 
+
+    def test_limit(self):
+        """
+        Test limited activity stream
+        """
+         
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+ 
+        result = self.sg.activity_stream_read(self._shot["type"], 
+                                              self._shot["id"], 
+                                              limit=1)
+        
+        self.assertEqual(len(result["updates"]), 1)
+        self.assertEqual(result["updates"][0]["update_type"], "create")
+        self.assertEqual(result["updates"][0]["meta"]["entity_type"], "Note")
+
+
+    def test_extra_fields(self):
+        """
+        Test additional fields for activity stream
+        """
+         
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+ 
+        result = self.sg.activity_stream_read(self._shot["type"], 
+                                              self._shot["id"], 
+                                              entity_fields={"Shot": ["created_by.HumanUser.image"], 
+                                                             "Note": ["content"]})
+        
+        self.assertEqual(len(result["updates"]), 2)
+        self.assertEqual(set(result["updates"][0]["primary_entity"].keys()), 
+                         set(["content",
+                              "id",
+                              "name",
+                              "status",
+                              "type"]))
+        
+        self.assertEqual(set(result["updates"][1]["primary_entity"].keys()), 
+                         set(["created_by.HumanUser.image",
+                              "id",
+                              "name",
+                              "status",
+                              "type"]))
+
+class TestNoteThreadRead(base.LiveTestBase):
+    """
+    Unit tests for the note_thread_read method
+    """
+     
+    def setUp(self):
+        super(TestNoteThreadRead, self).setUp()
+         
+    def _check_note(self, data, note_id, additional_fields):
+         
+        # check the expected fields
+        expected_fields = set(["content", "created_at", "created_by", "id", "type"] + additional_fields)
+         
+        self.assertEqual(expected_fields, set(data.keys()))
+         
+        # check that the data matches the data we get from a find call
+        note_data = self.sg.find_one("Note", 
+                                     [["id", "is", note_id]], 
+                                     list(expected_fields))
+        self.assertEqual(note_data, data)
+         
+    def _check_reply(self, data, reply_id, additional_fields):
+         
+        # check the expected fields
+        expected_fields = set(["content", "created_at", "user", "id", "type"] + additional_fields)
+        self.assertEqual(expected_fields, set(data.keys()))
+         
+        # check that the data matches the data we get from a find call
+        reply_data = self.sg.find_one("Reply", 
+                                     [["id", "is", reply_id]], 
+                                     list(expected_fields))
+        self.assertEqual(reply_data, data)
+         
+    def _check_attachment(self, data, attachment_id, additional_fields):
+         
+        # check the expected fields
+        expected_fields = set(["created_at", "created_by", "id", "type"] + additional_fields)
+        self.assertEqual(expected_fields, set(data.keys()))
+         
+        # check that the data matches the data we get from a find call
+        reply_data = self.sg.find_one("Attachment", 
+                                     [["id", "is", attachment_id]], 
+                                     list(expected_fields))
+         
+        self.assertEqual(reply_data, data)
+     
+    def test_simple(self):
+        """
+        Test note reply thread API call
+        """
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        # create note
+        note = self.sg.create( "Note", {"content": "Test!", "project": self.project})
+ 
+        # get thread
+        result = self.sg.note_thread_read(note["id"])
+        self.assertEqual(len(result), 1)
+        self._check_note(result[0], note["id"], additional_fields=[])
+         
+        # now add a reply
+        reply = self.sg.create( "Reply", {"content": "Reply Content", "entity": note})
+         
+        # get thread
+        result = self.sg.note_thread_read(note["id"])
+        self.assertEqual(len(result), 2)
+        self._check_note(result[0], note["id"], additional_fields=[])
+        self._check_reply(result[1], reply["id"], additional_fields=[])
+     
+        # now upload an attachment
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.abspath(os.path.join(this_dir, "sg_logo.jpg"))
+        attachment_id = self.sg.upload(note["type"], note["id"], path) 
+         
+        # get thread
+        result = self.sg.note_thread_read(note["id"])
+        self.assertEqual(len(result), 3)
+        self._check_note(result[0], note["id"], additional_fields=[])
+        self._check_reply(result[1], reply["id"], additional_fields=[])
+        self._check_attachment(result[2], attachment_id, additional_fields=[])
+         
+    def test_complex(self):
+        """
+        Test note reply thread API call with additional params
+        """
+         
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        additional_fields = { 
+              "Note":       ["created_by.HumanUser.image", 
+                             "addressings_to", 
+                             "playlist", 
+                             "user" ],
+              "Reply":      ["content"], 
+              "Attachment": ["local_storage", "this_file"]
+            }
+     
+        # create note
+        note = self.sg.create( "Note", {"content": "Test!", 
+                                        "project": self.project,
+                                        "addressings_to": [self.human_user]})
+ 
+        # get thread
+        result = self.sg.note_thread_read(note["id"], additional_fields)
+         
+        self.assertEqual(len(result), 1)
+        self._check_note(result[0], note["id"], additional_fields["Note"])
+         
+        # now add a reply
+        reply = self.sg.create( "Reply", {"content": "Reply Content", "entity": note})
+         
+        # get thread
+        result = self.sg.note_thread_read(note["id"], additional_fields)        
+        self.assertEqual(len(result), 2)
+        self._check_note(result[0], note["id"], additional_fields["Note"])
+        self._check_reply(result[1], reply["id"], additional_fields["Reply"])
+     
+        # now upload an attachment
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.abspath(os.path.join(this_dir, "sg_logo.jpg"))
+        attachment_id = self.sg.upload(note["type"], note["id"], path) 
+         
+        # get thread
+        result = self.sg.note_thread_read(note["id"], additional_fields)        
+        self.assertEqual(len(result), 3)
+        self._check_note(result[0], note["id"], additional_fields["Note"])
+        self._check_reply(result[1], reply["id"], additional_fields["Reply"])
+        self._check_attachment(result[2], attachment_id, additional_fields["Attachment"])
+        
+class TestTextSearch(base.LiveTestBase):
+    """
+    Unit tests for the text_search() method
+    """
+      
+    def setUp(self):
+        super(TestTextSearch, self).setUp()
+         
+        # create 5 shots and 5 assets to search for
+        self._prefix = uuid.uuid4().hex 
+         
+        batch_data = []
+        for i in range(5):
+            data = { "code":"%s Text Search %s" % (self._prefix, i),
+                     "project": self.project }
+            batch_data.append( {"request_type": "create",
+                                "entity_type": "Shot",
+                                "data": data} )        
+            batch_data.append( {"request_type": "create",
+                                "entity_type": "Asset",
+                                "data": data} )      
+        data = self.sg.batch(batch_data)
+ 
+        self._shot_ids = [x["id"] for x in data if x["type"] == "Shot"]
+        self._asset_ids = [x["id"] for x in data if x["type"] == "Asset"]
+         
+    def test_simple(self):
+        """
+        Test basic global search
+        """
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : {} } )
+         
+        self.assertEqual(set(["matches", "terms"]), set(result.keys()))
+        self.assertEqual(result["terms"], [self._prefix, "text", "search"])
+        matches = result["matches"]
+        self.assertEqual(len(matches), 5)
+         
+        for match in matches:
+            self.assertTrue(match["id"] in self._shot_ids)
+            self.assertEqual(match["type"], "Shot")
+            self.assertEqual(match["project_id"], self.project["id"])
+            self.assertEqual(match["image"], None)
+         
+    def test_limit(self):
+        """
+        Test limited global search
+        """
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : {} }, limit=3 )        
+        matches = result["matches"]
+        self.assertEqual(len(matches), 3)
+ 
+    def test_entity_filter(self):
+        """
+        Test basic multi-type global search
+        """
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        result = self.sg.text_search("%s Text Search" % self._prefix, 
+                                     {"Shot" : {}, "Asset": {} } )
+         
+        matches = result["matches"]
+         
+        self.assertEqual(set(["matches", "terms"]), set(result.keys()))
+        self.assertEqual(len(matches), 10)
+                 
+ 
+    def test_entity_filter(self):
+        """
+        Test complex multi-type global search
+        """
+        if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
+            return
+         
+        result = self.sg.text_search("%s Text Search" % self._prefix, 
+                                     {"Shot" : {"filters": [["code", "ends_with", "3"]]}, 
+                                      "Asset": {"filters": [["code", "ends_with", "4"]]} } )
+         
+        matches = result["matches"]
+         
+        self.assertEqual(set(["matches", "terms"]), set(result.keys()))
+        self.assertEqual(len(matches), 2)
+         
+        self.assertEqual(matches[0]["type"], "Shot")
+        self.assertEqual(matches[0]["name"], "%s Text Search 3" % self._prefix)
+        self.assertEqual(matches[1]["type"], "Asset")
+        self.assertEqual(matches[1]["name"], "%s Text Search 4" % self._prefix)
+         
+        
+
+
 
 def  _has_unicode(data):
     for k, v in data.items():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1947,7 +1947,7 @@ class TestTextSearch(base.LiveTestBase):
         if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
             return
          
-        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : {} } )
+        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : [] } )
          
         self.assertEqual(set(["matches", "terms"]), set(result.keys()))
         self.assertEqual(result["terms"], [self._prefix, "text", "search"])
@@ -1967,7 +1967,7 @@ class TestTextSearch(base.LiveTestBase):
         if not self.sg.server_caps.version or self.sg.server_caps.version < (6, 2, 0):
             return
          
-        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : {} }, limit=3 )        
+        result = self.sg.text_search("%s Text Search" % self._prefix, {"Shot" : [] }, limit=3 )        
         matches = result["matches"]
         self.assertEqual(len(matches), 3)
  
@@ -1979,7 +1979,7 @@ class TestTextSearch(base.LiveTestBase):
             return
          
         result = self.sg.text_search("%s Text Search" % self._prefix, 
-                                     {"Shot" : {}, "Asset": {} } )
+                                     {"Shot": [], "Asset": [] } )
          
         matches = result["matches"]
          
@@ -1987,7 +1987,7 @@ class TestTextSearch(base.LiveTestBase):
         self.assertEqual(len(matches), 10)
                  
  
-    def test_entity_filter(self):
+    def test_complex_entity_filter(self):
         """
         Test complex multi-type global search
         """
@@ -1995,8 +1995,13 @@ class TestTextSearch(base.LiveTestBase):
             return
          
         result = self.sg.text_search("%s Text Search" % self._prefix, 
-                                     {"Shot" : {"filters": [["code", "ends_with", "3"]]}, 
-                                      "Asset": {"filters": [["code", "ends_with", "4"]]} } )
+                                     {"Shot": [["code", "ends_with", "3"]], 
+                                      "Asset": [
+                                                {"filter_operator": "any", 
+                                                 "filters": [["code", "ends_with", "4"]]
+                                                }
+                                                ]
+                                     })
          
         matches = result["matches"]
          


### PR DESCRIPTION
Adds three new methods:

- `text_search()` gives access to the shotgun global search and auto completer.
- `activity_stream_read()` gives access to the shotgun actitivty stream.
- `note_thread_read()` gives access to a note thread, including replies and attachments, via a single call.