### PR TITLE
#34265 add handling for Python versions incompatible with SHA-2

### DIFF
--- a/shotgun_api3/sg_24.py
+++ b/shotgun_api3/sg_24.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 
-from shotgun_api3.lib.httplib2 import Http, ProxyInfo, socks
+from shotgun_api3.lib.httplib2 import Http, ProxyInfo, socks, SSLHandshakeError
 from shotgun_api3.lib.sgtimezone import SgTimezone
 from shotgun_api3.lib.xmlrpclib import Error, ProtocolError, ResponseError
 import mimetypes    # used for attachment upload

--- a/shotgun_api3/sg_25.py
+++ b/shotgun_api3/sg_25.py
@@ -2,7 +2,7 @@ import sys
 import os
 import logging
 
-from .lib.httplib2 import Http, ProxyInfo, socks
+from .lib.httplib2 import Http, ProxyInfo, socks, SSLHandshakeError
 from .lib.sgtimezone import SgTimezone
 from .lib.xmlrpclib import Error, ProtocolError, ResponseError
 import mimetypes    # used for attachment upload

--- a/shotgun_api3/sg_26.py
+++ b/shotgun_api3/sg_26.py
@@ -2,7 +2,7 @@ import sys
 import os
 import logging
 
-from .lib.httplib2 import Http, ProxyInfo, socks
+from .lib.httplib2 import Http, ProxyInfo, socks, SSLHandshakeError
 from .lib.sgtimezone import SgTimezone
 from .lib.xmlrpclib import Error, ProtocolError, ResponseError
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -70,7 +70,7 @@ NO_SSL_VALIDATION = False
 try:
     import ssl        
 except ImportError, e:
-    if os.environ.get("SHOTGUN_FORCE_CERTIFICATE_VALIDATION") not in [0, "0", "", None]:
+    if "SHOTGUN_FORCE_CERTIFICATE_VALIDATION" in os.environ:
         raise ImportError("%s. SHOTGUN_FORCE_CERTIFICATE_VALIDATION environment variable prevents "
                           "disabling SSL certificate validation." % e)
     else:
@@ -218,10 +218,27 @@ class ClientCapabilities(object):
 
         self.py_version = ".".join(str(x) for x in sys.version_info[:2])
 
+        # extract the OpenSSL version if we can. The version is only available in Python 2.7 and
+        # only if we successfully imported ssl
+        ssl_version_str = None
+        ssl_version_num = "unknown"
+        try:
+            ssl_version_str = ssl.OPENSSL_VERSION
+        except AttributeError, NameError:
+            pass
+        if ssl_version_str:
+            try:
+                ssl_version_num = re.search("openssl\s*([\S.]+).*", ssl_version_str, 
+                                            flags=re.IGNORECASE).group(1)
+            except AttributeError:
+                # the version string format isn't right
+                pass
+        self.ssl_version = ssl_version_num
+
     def __str__(self):
         return "ClientCapabilities: platform %s, local_path_field %s, "\
-            "py_verison %s" % (self.platform, self.local_path_field,
-            self.py_version)
+            "py_verison %s, ssl version %s" % (self.platform, self.local_path_field,
+            self.py_version, self.ssl_version)
 
 class _Config(object):
     """Container for the client configuration."""
@@ -1260,14 +1277,21 @@ class Shotgun(object):
     def reset_user_agent(self):
         """Reset user agent to the default.
 
-        Eg. shotgun-json (3.0.17); Python 2.6 (Mac)
+        Eg. "shotgun-json (3.0.17); Python 2.6 (Mac); ssl 0.9.8a validate"
         """
         ua_platform = "Unknown"
         if self.client_caps.platform is not None:
             ua_platform = self.client_caps.platform.capitalize()
+        
+
+        # create ssl validation string based on settings
+        validation_str = "validate"
+        if self.config.no_ssl_validation:
+            validation_str = "no-validate"
+        
         self._user_agents = ["shotgun-json (%s)" % __version__,
                              "Python %s (%s)" % (self.client_caps.py_version, ua_platform),
-                             "ssl-validation %s" % (int(self.config.no_ssl_validation is False))]
+                             "ssl %s %s" % (self.client_caps.ssl_version, validation_str)]
 
 
     def set_session_uuid(self, session_uuid):
@@ -2009,8 +2033,8 @@ class Shotgun(object):
         self.config.no_ssl_validation = True
         NO_SSL_VALIDATION = True
         # reset ssl-validation in user-agents
-        self._user_agents = ["ssl-validation 0" 
-                             if ua.startswith("ssl-validation ") else ua 
+        self._user_agents = ["ssl %s no-validate" % self.client_caps.ssl_version 
+                             if ua.startswith("ssl ") else ua 
                              for ua in self._user_agents] 
 
     # Deprecated methods from old wrapper
@@ -2177,20 +2201,30 @@ class Shotgun(object):
             try:
                 return self._http_request(verb, path, body, req_headers)
             except SSLHandshakeError, e:
-                # Not a SHA-2 error or SHA-2 error we want to enforce. SHA-2 errors look like: 
+                # Test whether the exception is due to the fact that this is an older version of
+                # Python that cannot validate certificates encrypted with SHA-2. If it is, then 
+                # fall back on disabling the certificate validation and try again - unless the
+                # SHOTGUN_FORCE_CERTIFICATE_VALIDATION environment variable has been set by the 
+                # user. In that case we simply raise the exception. Any other exceptions simply 
+                # get raised as well. 
                 #
+                # For more info see:
+                # http://blog.shotgunsoftware.com/2016/01/important-ssl-certificate-renewal-and.html
+                #
+                # SHA-2 errors look like this: 
                 #   [Errno 1] _ssl.c:480: error:0D0C50A1:asn1 encoding routines:ASN1_item_verify:
                 #   unknown message digest algorithm
-                #
-                # valid values should be "0" and "1" but we're trying to catch edge cases too
+                # 
+                # Any other exceptions simply get raised.
                 if not str(e).endswith("unknown message digest algorithm") or \
-                   os.environ.get("SHOTGUN_FORCE_CERTIFICATE_VALIDATION") not in [0, "0", "", None]:
+                   "SHOTGUN_FORCE_CERTIFICATE_VALIDATION" in os.environ:
                     raise
                 
-                LOG.warning("SSLHandshakeError: this Python installation is incompatible with "
-                            "certificates signed with SHA-2. Disabling certificate validation. "
-                            "For more information, see http://blog.shotgunsoftware.com/2016/01/"
-                            "important-ssl-certificate-renewal-and.html")
+                if self.config.no_ssl_validation is False:
+                    LOG.warning("SSLHandshakeError: this Python installation is incompatible with "
+                                "certificates signed with SHA-2. Disabling certificate validation. "
+                                "For more information, see http://blog.shotgunsoftware.com/2016/01/"
+                                "important-ssl-certificate-renewal-and.html")
                 self._close_connection()
                 self._turn_off_ssl_validation()
                 # reload user agent to reflect that we have turned off ssl validation

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2178,7 +2178,7 @@ class Shotgun(object):
                 # sha-2 errors look like: 
                 #   [Errno 1] _ssl.c:480: error:0D0C50A1:asn1 encoding routines:ASN1_item_verify:
                 #   unknown message digest algorithm
-                if not str(e).endswith("unknown message digest algorithm") or 
+                if not str(e).endswith("unknown message digest algorithm") or \
                    "SHOTGUN_FORCE_CERTIFICATE_VALIDATION" in os.environ:
                     raise
                 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2174,17 +2174,20 @@ class Shotgun(object):
             try:
                 return self._http_request(verb, path, body, req_headers)
             except SSLHandshakeError, e:
-                # not a sha2 error or sha2 error we want to enforce
-                # sha-2 errors look like: 
+                # Not a SHA-2 error or SHA-2 error we want to enforce. SHA-2 errors look like: 
+                #
                 #   [Errno 1] _ssl.c:480: error:0D0C50A1:asn1 encoding routines:ASN1_item_verify:
                 #   unknown message digest algorithm
+                #
                 if not str(e).endswith("unknown message digest algorithm") or \
-                   "SHOTGUN_FORCE_CERTIFICATE_VALIDATION" in os.environ:
+                   # valid values should be "0" and "1" but we're trying to catch edge cases too
+                   os.environ.get("SHOTGUN_FORCE_CERTIFICATE_VALIDATION") not in [0, "0", "", None]:
                     raise
                 
                 LOG.warning("SSLHandshakeError: this Python installation is incompatible with "
                             "certificates signed with SHA-2. Disabling certificate validation. "
-                            "For more information, see http://blog.shotgunsoftware.com/2016/01/important-ssl-certificate-renewal-and.html")
+                            "For more information, see http://blog.shotgunsoftware.com/2016/01/"
+                            "important-ssl-certificate-renewal-and.html")
                 self._close_connection()
                 self._turn_off_ssl_validation()
                 # reload user agent to reflect that we have turned off ssl validation

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -66,17 +66,20 @@ LOG.setLevel(logging.WARN)
 
 SG_TIMEZONE = SgTimezone()
 
-
+NO_SSL_VALIDATION = False
 try:
-    import ssl
-    NO_SSL_VALIDATION = False
-except ImportError:
-    LOG.debug("ssl not found, disabling certificate validation")
-    NO_SSL_VALIDATION = True
+    import ssl        
+except ImportError, e:
+    if os.environ.get("SHOTGUN_FORCE_CERTIFICATE_VALIDATION") not in [0, "0", "", None]:
+        raise ImportError("%s. SHOTGUN_FORCE_CERTIFICATE_VALIDATION environment variable prevents "
+                          "disabling SSL certificate validation." % e)
+    else:
+        LOG.debug("ssl not found, disabling certificate validation")
+        NO_SSL_VALIDATION = True
 
 # ----------------------------------------------------------------------------
 # Version
-__version__ = "3.0.24"
+__version__ = "3.0.25.Dev"
 
 # ----------------------------------------------------------------------------
 # Errors

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2179,8 +2179,8 @@ class Shotgun(object):
                 #   [Errno 1] _ssl.c:480: error:0D0C50A1:asn1 encoding routines:ASN1_item_verify:
                 #   unknown message digest algorithm
                 #
+                # valid values should be "0" and "1" but we're trying to catch edge cases too
                 if not str(e).endswith("unknown message digest algorithm") or \
-                   # valid values should be "0" and "1" but we're trying to catch edge cases too
                    os.environ.get("SHOTGUN_FORCE_CERTIFICATE_VALIDATION") not in [0, "0", "", None]:
                     raise
                 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -222,7 +222,7 @@ class ClientCapabilities(object):
         self.ssl_version = "unknown"
         try:
             self.ssl_version = ssl.OPENSSL_VERSION
-        except AttributeError, NameError:
+        except (AttributeError, NameError):
             pass
 
     def __str__(self):

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1267,7 +1267,7 @@ class Shotgun(object):
     def reset_user_agent(self):
         """Reset user agent to the default.
 
-        Eg. "shotgun-json (3.0.17); Python 2.6 (Mac); ssl 0.9.8a validate"
+        Eg. "shotgun-json (3.0.17); Python 2.6 (Mac); ssl OpenSSL 1.0.2d 9 Jul 2015 (validate)"
         """
         ua_platform = "Unknown"
         if self.client_caps.platform is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1480,19 +1480,25 @@ class TestErrors(base.TestBase):
         # save the original state
         original_env_val = os.environ.pop("SHOTGUN_FORCE_CERTIFICATE_VALIDATION", None)
 
+        # ensure we're starting with the right values
+        self.sg.config.no_ssl_validation = False
+        shotgun_api3.shotgun.NO_SSL_VALIDATION = False
+        self.sg.reset_user_agent()
+
         # ensure the initial settings are correct
+        # note the space before 'validate' so we don't accidentally match 'no-validate'
         self.assertFalse(self.sg.config.no_ssl_validation)
         self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-        self.assertTrue("ssl-validation 1" in self.sg._user_agents)
-        self.assertFalse("ssl-validation 0" in self.sg._user_agents)
+        self.assertTrue(" validate" in " ".join(self.sg._user_agents))
+        self.assertFalse("no-validate" in " ".join(self.sg._user_agents))
         try:
             result = self.sg.info()
         except SSLHandshakeError:
             # ensure the api has reset the values in the correct fallback behavior
             self.assertTrue(self.sg.config.no_ssl_validation)
             self.assertTrue(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-            self.assertTrue("ssl-validation 0" in self.sg._user_agents)
-            self.assertFalse("ssl-validation 1" in self.sg._user_agents)
+            self.assertFalse(" validate" in " ".join(self.sg._user_agents))
+            self.assertTrue("no-validate" in " ".join(self.sg._user_agents))
 
         if original_env_val is not None:
             os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val
@@ -1508,6 +1514,11 @@ class TestErrors(base.TestBase):
         original_env_val = os.environ.pop("SHOTGUN_FORCE_CERTIFICATE_VALIDATION", None)
         os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = "1"
         
+        # ensure we're starting with the right values
+        self.sg.config.no_ssl_validation = False
+        shotgun_api3.shotgun.NO_SSL_VALIDATION = False
+        self.sg.reset_user_agent()
+
         try:
             result = self.sg.info()
         except SSLHandshakeError:
@@ -1515,8 +1526,8 @@ class TestErrors(base.TestBase):
             # set the env variable to force validation
             self.assertFalse(self.sg.config.no_ssl_validation)
             self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-            self.assertFalse("ssl-validation 0" in self.sg._user_agents)
-            self.assertTrue("ssl-validation 1" in self.sg._user_agents)
+            self.assertFalse("no-validate" in " ".join(self.sg._user_agents))
+            self.assertTrue(" validate" in " ".join(self.sg._user_agents))
 
         if original_env_val is not None:
             os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1481,24 +1481,21 @@ class TestErrors(base.TestBase):
         original_env_val = os.environ.pop("SHOTGUN_FORCE_CERTIFICATE_VALIDATION", None)
 
         # ensure we're starting with the right values
-        self.sg.config.no_ssl_validation = False
-        shotgun_api3.shotgun.NO_SSL_VALIDATION = False
         self.sg.reset_user_agent()
 
         # ensure the initial settings are correct
-        # note the space before 'validate' so we don't accidentally match 'no-validate'
         self.assertFalse(self.sg.config.no_ssl_validation)
         self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-        self.assertTrue(" validate" in " ".join(self.sg._user_agents))
-        self.assertFalse("no-validate" in " ".join(self.sg._user_agents))
+        self.assertTrue("(validate)" in " ".join(self.sg._user_agents))
+        self.assertFalse("(no-validate)" in " ".join(self.sg._user_agents))
         try:
             result = self.sg.info()
         except SSLHandshakeError:
             # ensure the api has reset the values in the correct fallback behavior
             self.assertTrue(self.sg.config.no_ssl_validation)
             self.assertTrue(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-            self.assertFalse(" validate" in " ".join(self.sg._user_agents))
-            self.assertTrue("no-validate" in " ".join(self.sg._user_agents))
+            self.assertFalse("(validate)" in " ".join(self.sg._user_agents))
+            self.assertTrue("(no-validate)" in " ".join(self.sg._user_agents))
 
         if original_env_val is not None:
             os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val
@@ -1526,8 +1523,8 @@ class TestErrors(base.TestBase):
             # set the env variable to force validation
             self.assertFalse(self.sg.config.no_ssl_validation)
             self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
-            self.assertFalse("no-validate" in " ".join(self.sg._user_agents))
-            self.assertTrue(" validate" in " ".join(self.sg._user_agents))
+            self.assertFalse("(no-validate)" in " ".join(self.sg._user_agents))
+            self.assertTrue("(validate)" in " ".join(self.sg._user_agents))
 
         if original_env_val is not None:
             os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ import urlparse
 import urllib2
 
 import shotgun_api3
-from shotgun_api3.lib.httplib2 import Http
+from shotgun_api3.lib.httplib2 import Http, SSLHandshakeError
 
 import base
 
@@ -1469,6 +1469,57 @@ class TestErrors(base.TestBase):
         response.reason = 'reason'
         mock_request.return_value = (response, {})
         self.assertRaises(shotgun_api3.ProtocolError, self.sg.find_one, 'Shot', [])
+
+    @patch('shotgun_api3.shotgun.Http.request')
+    def test_sha2_error(self, mock_request):
+        # Simulate the SSLHandshakeError raised with SHA-2 errors
+        mock_request.side_effect = SSLHandshakeError("[Errno 1] _ssl.c:480: error:0D0C50A1:asn1 "
+                                    "encoding routines:ASN1_item_verify: unknown message digest "
+                                    "algorithm")
+
+        # save the original state
+        original_env_val = os.environ.pop("SHOTGUN_FORCE_CERTIFICATE_VALIDATION", None)
+
+        # ensure the initial settings are correct
+        self.assertFalse(self.sg.config.no_ssl_validation)
+        self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
+        self.assertTrue("ssl-validation 1" in self.sg._user_agents)
+        self.assertFalse("ssl-validation 0" in self.sg._user_agents)
+        try:
+            result = self.sg.info()
+        except SSLHandshakeError:
+            # ensure the api has reset the values in the correct fallback behavior
+            self.assertTrue(self.sg.config.no_ssl_validation)
+            self.assertTrue(shotgun_api3.shotgun.NO_SSL_VALIDATION)
+            self.assertTrue("ssl-validation 0" in self.sg._user_agents)
+            self.assertFalse("ssl-validation 1" in self.sg._user_agents)
+
+        if original_env_val is not None:
+            os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val
+
+    @patch('shotgun_api3.shotgun.Http.request')
+    def test_sha2_error_with_strict(self, mock_request):
+        # Simulate the SSLHandshakeError raised with SHA-2 errors
+        mock_request.side_effect = SSLHandshakeError("[Errno 1] _ssl.c:480: error:0D0C50A1:asn1 "
+                                    "encoding routines:ASN1_item_verify: unknown message digest "
+                                    "algorithm")
+
+        # save the original state
+        original_env_val = os.environ.pop("SHOTGUN_FORCE_CERTIFICATE_VALIDATION", None)
+        os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = "1"
+        
+        try:
+            result = self.sg.info()
+        except SSLHandshakeError:
+            # ensure the api has NOT reset the values in the fallback behavior because we have
+            # set the env variable to force validation
+            self.assertFalse(self.sg.config.no_ssl_validation)
+            self.assertFalse(shotgun_api3.shotgun.NO_SSL_VALIDATION)
+            self.assertFalse("ssl-validation 0" in self.sg._user_agents)
+            self.assertTrue("ssl-validation 1" in self.sg._user_agents)
+
+        if original_env_val is not None:
+            os.environ["SHOTGUN_FORCE_CERTIFICATE_VALIDATION"] = original_env_val
 
     @patch.object(urllib2.OpenerDirector, 'open')
     def test_sanitized_auth_params(self, mock_open):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -158,12 +158,15 @@ class TestShotgunClient(base.MockTestBase):
         # test default user agent
         self.sg.info()
         client_caps = self.sg.client_caps
+        config = self.sg.config
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s)" % (api.__version__, 
-                                                          client_caps.py_version,
-                                                          client_caps.platform.capitalize()
-                                                          )
+        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d" % (
+                                                        api.__version__, 
+                                                        client_caps.py_version,
+                                                        client_caps.platform.capitalize(),
+                                                        int(config.no_ssl_validation is False)
+                                                        )
         self.assertEqual(expected, headers.get("user-agent"))
 
         # test adding to user agent

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -164,7 +164,7 @@ class TestShotgunClient(base.MockTestBase):
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
         ssl_validate_lut = {True: "no-validate", False: "validate"}
-        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s" % (
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s (%s)" % (
                         api.__version__, 
                         client_caps.py_version,
                         client_caps.platform.capitalize(),
@@ -178,7 +178,7 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s; test-agent" % (
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s (%s); test-agent" % (
                         api.__version__, 
                         client_caps.py_version,
                         client_caps.platform.capitalize(),
@@ -192,7 +192,7 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s" % (
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s (%s)" % (
                         api.__version__, 
                         client_caps.py_version,
                         client_caps.platform.capitalize(),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,8 @@ class TestShotgunClient(base.MockTestBase):
         self.assertTrue(str(client_caps).startswith("ClientCapabilities"))
         self.assertTrue(client_caps.py_version.startswith(str(sys.version_info[0])))
         self.assertTrue(client_caps.py_version.endswith(str(sys.version_info[1])))
+        self.assertTrue(client_caps.ssl_version is not None)
+        # todo test for version string (eg. "1.2.3ng") or "unknown"
 
     def test_detect_server_caps(self):
         '''test_detect_server_caps tests that ServerCapabilities object is made
@@ -161,12 +163,14 @@ class TestShotgunClient(base.MockTestBase):
         config = self.sg.config
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d" % (
-                                                        api.__version__, 
-                                                        client_caps.py_version,
-                                                        client_caps.platform.capitalize(),
-                                                        int(config.no_ssl_validation is False)
-                                                        )
+        ssl_validate_lut = {True: "no-validate", False: "validate"}
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s" % (
+                        api.__version__, 
+                        client_caps.py_version,
+                        client_caps.platform.capitalize(),
+                        client_caps.ssl_version,
+                        ssl_validate_lut[config.no_ssl_validation]
+                        )
         self.assertEqual(expected, headers.get("user-agent"))
 
         # test adding to user agent
@@ -174,11 +178,12 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d; test-agent" % (
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s; test-agent" % (
                         api.__version__, 
                         client_caps.py_version,
                         client_caps.platform.capitalize(),
-                        int(config.no_ssl_validation is False)
+                        client_caps.ssl_version,
+                        ssl_validate_lut[config.no_ssl_validation]
                         )
         self.assertEqual(expected, headers.get("user-agent"))
 
@@ -187,11 +192,13 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d" % (api.__version__, 
-                                                          client_caps.py_version,
-                                                          client_caps.platform.capitalize(),
-                                                          int(config.no_ssl_validation is False)
-                                                          )
+        expected = "shotgun-json (%s); Python %s (%s); ssl %s %s" % (
+                        api.__version__, 
+                        client_caps.py_version,
+                        client_caps.platform.capitalize(),
+                        client_caps.ssl_version,
+                        ssl_validate_lut[config.no_ssl_validation]
+                        )
         self.assertEqual(expected, headers.get("user-agent"))
 
     def test_connect_close(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -174,10 +174,11 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s); test-agent" % (
+        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d; test-agent" % (
                         api.__version__, 
                         client_caps.py_version,
-                        client_caps.platform.capitalize()
+                        client_caps.platform.capitalize(),
+                        int(config.no_ssl_validation is False)
                         )
         self.assertEqual(expected, headers.get("user-agent"))
 
@@ -186,9 +187,10 @@ class TestShotgunClient(base.MockTestBase):
         self.sg.info()
         args, _ = self.sg._http_request.call_args
         (_, _, _, headers) = args
-        expected = "shotgun-json (%s); Python %s (%s)" % (api.__version__, 
+        expected = "shotgun-json (%s); Python %s (%s); ssl-validation %d" % (api.__version__, 
                                                           client_caps.py_version,
                                                           client_caps.platform.capitalize(),
+                                                          int(config.no_ssl_validation is False)
                                                           )
         self.assertEqual(expected, headers.get("user-agent"))
 


### PR DESCRIPTION
#### Change in behavior
We are updating our server certificates to more secure ones signed with SHA-2. Some older versions of Python will have issues with this change as they do not support SHA-2 encryption. In order to try and prevent scripts from breaking, when the API encounters a version of Python that is incompatible with SHA-2, it will automatically turn off certificate verification and try the request again. If the validation still fails for some reason, the error will be raised, otherwise the request succeeds and validation will remain off for the remaining life of the connection.

This behavior of having certificate validation off, is actually the default in Python versions < v2.7.9. Up to this point we have been electing to enhance the default level of security. Your connection is still encrypted when certificate validation is off, but the server identity cannot be verified.

#### Logging warnings
When the connection falls back to not validating the certificate, a warning message is generated in the logs:

```
Warning: shotgun_api3 : SSLHandshakeError: this Python installation is incompatible with certificates signed with SHA-2. Disabling certificate validation. For more information, see http://blog.shotgunsoftware.com/2016/01/important-ssl-certificate-renewal-and.html
```

#### `SHOTGUN_FORCE_CERTIFICATE_VALIDATION` environment variable support
There is also support for the `SHOTGUN_FORCE_CERTIFICATE_VALIDATION` environment variable which when set (the value does not matter), will prevent disabling certificate verification and will instead raise an exception.

#### SSL info added to user-agent
Adds info showing the OpenSSL version (if available) and whether certificate validation is enabled or not, to the user-agent string: 

`ssl OpenSSL 1.0.2d 9 Jul 2015 (no-validate)` when validation is disabled
`ssl OpenSSL 1.0.2d 9 Jul 2015 (validate)` when validation is enabled
`ssl OpenSSL unknown (validate)` when the ssl version cannot be determined (< Python 2.7)


