### PR TITLE
For #33172, support ampersand in proxy authentication passwords

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -429,8 +429,9 @@ class Shotgun(object):
 
         # foo:bar@123.456.789.012:3456
         if http_proxy:
-            # check if we're using authentication
-            p = http_proxy.split("@", 1)
+            # check if we're using authentication. Start from the end since there might be
+            # @ in the user's password.
+            p = http_proxy.rsplit("@", 1)
             if len(p) > 1:
                 self.config.proxy_user, self.config.proxy_pass = \
                     p[0].split(":", 1)

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -85,7 +85,7 @@ class TestShotgunInit(unittest.TestCase):
         self.assertEquals(sg.config.proxy_user, proxy_user)
         self.assertEquals(sg.config.proxy_pass, proxy_pass)
 
-    def test_http_proxy_with_ampersand_in_password(self):
+    def test_http_proxy_with_at_in_password(self):
         proxy_server = "someserver.com"
         proxy_port = 1234
         proxy_user = "user"

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -84,6 +84,23 @@ class TestShotgunInit(unittest.TestCase):
         self.assertEquals(sg.config.proxy_port, proxy_port)
         self.assertEquals(sg.config.proxy_user, proxy_user)
         self.assertEquals(sg.config.proxy_pass, proxy_pass)
+
+    def test_http_proxy_with_ampersand_in_password(self):
+        proxy_server = "someserver.com"
+        proxy_port = 1234
+        proxy_user = "user"
+        proxy_pass = "p@ssword"
+        http_proxy = "%s:%s@%s:%d" % (proxy_user, proxy_pass, proxy_server, 
+                                      proxy_port)
+        sg = api.Shotgun(self.server_path, 
+                         self.script_name, 
+                         self.api_key, 
+                         http_proxy=http_proxy,
+                         connect=False)
+        self.assertEquals(sg.config.proxy_server, proxy_server)
+        self.assertEquals(sg.config.proxy_port, proxy_port)
+        self.assertEquals(sg.config.proxy_user, proxy_user)
+        self.assertEquals(sg.config.proxy_pass, proxy_pass)
  
     def test_malformatted_proxy_info(self):
         proxy_server = "someserver.com"


### PR DESCRIPTION
Splitting the string on @ was the right idea, but we have to do it from the end, since the password might have @ in it. Splitting from the end is safe since the the host and port number can't have this character.