### PR TITLE
For #10692: Option to use add/remove/set modes when updating multi-entity fields

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -853,10 +853,10 @@ class Shotgun(object):
         :param multi_entity_update_modes: Optional, dict of what update mode to
         use when updating a multi-entity link field.  The keys in the dict are
         the fields to set the mode for and the values from the dict are one
-        of "set", "add", or "remove". The default behaviour is to use "set" if a
-        field being updated doesn't have an explicitly set mode. For example,
-        to append to the 'shots' field and remove from the 'assets' field on
-        a 'Sequence', you would specify:
+        of "set", "add", or "remove". The default behavior if mode is not
+        specified for a field is 'set'. For example, on the 'Sequence' entity,
+        to append to the 'shots' field and remove from the 'assets' field, you
+        would specify:
 
             multi_entity_update_modes={"shots":"add", "assets":"remove"}
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -26,6 +26,7 @@ class TestBase(unittest.TestCase):
         self.asset          = None
         self.version        = None
         self.note           = None
+        self.playlist       = None
         self.task           = None
         self.ticket         = None
         self.human_password = None
@@ -180,9 +181,12 @@ class MockTestBase(TestBase):
         self.version    = { 'id':5,
                             'code':self.config.version_code,
                             'type':'Version' }
-        self.ticket    = { 'id':6,
+        self.ticket     = { 'id':6,
                             'title':self.config.ticket_title,
                             'type':'Ticket' }
+        self.playlist   = { 'id':7,
+                            'code':self.config.playlist_code,
+                            'type':'Playlist'}
 
 class LiveTestBase(TestBase):
     '''Test base for tests relying on connection to server.'''
@@ -236,6 +240,11 @@ class LiveTestBase(TestBase):
                 'content':'anything'}
         self.note = _find_or_create_entity(self.sg, 'Note', data, keys)
 
+        keys = ['code','project']
+        data = {'project':self.project,
+                'code':self.config.playlist_code}
+        self.playlist = _find_or_create_entity(self.sg, 'Playlist', data, keys)
+
         keys = ['code', 'entity_type']
         data = {'code': 'wrapper test step',
                 'entity_type': 'Shot'}
@@ -262,7 +271,6 @@ class LiveTestBase(TestBase):
                 'mac_path':'nowhere',
                 'windows_path':'nowhere',
                 'linux_path':'nowhere'}
-
         self.local_storage = _find_or_create_entity(self.sg, 'LocalStorage', data, keys)
 
 

--- a/tests/example_config
+++ b/tests/example_config
@@ -23,4 +23,5 @@ asset_code     : Sg unittest asset
 version_code   : Sg unittest version
 shot_code      : Sg unittest shot
 task_content   : Sg unittest task
-ticket_title    : Sg unittest ticket
+ticket_title   : Sg unittest ticket
+playlist_code  : Sg unittest playlist


### PR DESCRIPTION
This update will allow for updating multi-entity fields without having to pull down the field's entire dataset first.

It uses the new parameter ```multi_entity_update_modes``` on the update method to specify one of 'add', 'remove', or 'set'.

As this update is tied to a change on the server-side, it should not be merged until that pull request is merged and released.