### PR TITLE
#35872 shotgun.py: optional extra_auth_params added to Config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ Integration and unit tests are provided.
 
 [![Build Status](https://secure.travis-ci.org/shotgunsoftware/python-api.png?branch=master)](http://travis-ci.org/shotgunsoftware/python-api)
 
-- test_client and tests_unit mock server interaction and do not require a shotgun instance to be available.
-- test_api and test_api_long do require a shotgun instance, with a script key available for the tests. These tests rely on a tests/config file, which can be created by renaming example_config and supplying the server and script user values. The tests will set up test data on the server based on the data set forth in the config. This data will be manipulated by the tests, and should not be used for other purposes.
-- To run all of the tests, use the shell script run-tests. This script require nose to be installed.
+- All tests require the "nose" unit testing tools (http://nose.readthedocs.org), and a "tests/config" file (copy from "tests/example_config").
+- Tests can be run individually like this: `nosetest tests/test_client.py`
+- test_client and tests_unit use mock server interaction and do not require a shotgun instance to be available (no modifacations to tests/config necessary).
+- test_api and test_api_long do require a shotgun instance, with a script key available for the tests. The server and script user values must be supplied in the tests/config file. The tests will set up test data on the server based on the data set forth in the config. This data will be manipulated by the tests, and should not be used for other purposes.
+- To run all of the tests, use the shell script run-tests.
 
 ## Changelog
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -249,6 +249,8 @@ class _Config(object):
         self.user_password = None
         self.auth_token = None
         self.sudo_as_login = None
+        # Authentication parameters to be folded into final auth_params dict
+        self.extra_auth_params = None
         # uuid as a string
         self.session_uuid = None
         self.scheme = None
@@ -2125,6 +2127,9 @@ class Shotgun(object):
                 raise ShotgunError("Option 'sudo_as_login' requires server version 5.3.12 or "\
                     "higher, server is %s" % (self.server_caps.version,))
             auth_params["sudo_as_login"] = self.config.sudo_as_login
+
+        if self.config.extra_auth_params:
+            auth_params.update(self.config.extra_auth_params)
 
         return auth_params
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,6 +89,26 @@ class TestShotgunClient(base.MockTestBase):
         sc.version = (2,5,0)
         sc._ensure_json_supported()
 
+    def test_extra_auth_params(self):
+        """test_extra_auth_params tests provided auth_params are included in request"""
+        # ok for the mock server to just return an error, we want to look at
+        # what's in the request
+        self._mock_http({ "message":"Go BANG",
+                          "exception":True })
+
+        def auth_args():
+            args = self.sg._http_request.call_args[0]
+            body = args[2]
+            body = json.loads(body)
+            return body["params"][0]
+
+        self.sg.config.extra_auth_params = None
+        self.assertRaises(api.Fault, self.sg.delete, "FakeType", 1)
+        self.assertTrue("product" not in auth_args())
+
+        self.sg.config.extra_auth_params = {"product":"rv"}
+        self.assertRaises(api.Fault, self.sg.delete, "FakeType", 1)
+        self.assertEqual("rv", auth_args()["product"])
 
     def test_session_uuid(self):
         """test_session_uuid tests session UUID is included in request"""


### PR DESCRIPTION
**Commit Details:**
* As of Shotgun 5.4.10, session tokens are distinguished by a "product" field depending on how they were created.  If the appropriate product is not supplied with the session_token, any authentication request with that token will fail.

* We add an optional "extra_auth_params" member to the Config object so  that we can pass in the "product" when needed, and other supplementary params  we might add in the future.

* New client_test "test_extra_auth_params()" succeeds with changes in this commit.

* README.md refreshed a little.

**Usage Example**

```python
    def create_sg_connection(self):
        """
        Create a Shotgun instance using the script user's credentials.
        :returns: A Shotgun instance.
        """
        # Delay the connection so that we can adjust the Config manually.
        shotgun_obj = Shotgun(
            self.get_host(),
            session_token=self._session_token,
            connect=False,
            http_proxy=self._http_proxy
        )
        # The API must be notified that the session token in this case is the
        # result of an RV licensing request.
        shotgun_obj.config.extra_auth_params = { "product": "rv" }
        shotgun_obj.server_caps
```