### PR TITLE
#35786 Adds basic find() ordering support to mockgun.

### DIFF
--- a/shotgun_api3/lib/mockgun.py
+++ b/shotgun_api3/lib/mockgun.py
@@ -352,7 +352,7 @@ class Shotgun(object):
             # order: [{"field_name": "code", "direction": "asc"}, ... ]
             for order_entry in order:
                 if "field_name" not in order_entry:
-                    raise ValueError("Order clauses must be list of dicts with keys field_name and direction!")
+                    raise ValueError("Order clauses must be list of dicts with keys 'field_name' and 'direction'!")
 
                 order_field = order_entry["field_name"]
                 if order_entry["direction"] == "asc":


### PR DESCRIPTION
Previously, mockgun just ignored the ordering parameter on `find()` and `find_one()`. This adds basic ordering support. This change is needed for the unit test added here: https://github.com/shotgunsoftware/tk-core/pull/266