### PR TITLE
For #36143: Explicitly closing download_attachment file handler

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1586,6 +1586,7 @@ class Shotgun(object):
             req = urllib2.urlopen(request)
             if file_path:
                 shutil.copyfileobj(req, fp)
+                fp.close()
             else:
                 attachment = req.read()
         # 400 [sg] Attachment id doesn't exist or is a local file
@@ -1612,6 +1613,8 @@ class Shotgun(object):
             raise ShotgunFileDownloadError(err)
         else:
             if file_path:
+                if not fp.closed:
+                    fp.close()
                 return file_path
             else:
                 return attachment

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1586,7 +1586,6 @@ class Shotgun(object):
             req = urllib2.urlopen(request)
             if file_path:
                 shutil.copyfileobj(req, fp)
-                fp.close()
             else:
                 attachment = req.read()
         # 400 [sg] Attachment id doesn't exist or is a local file


### PR DESCRIPTION
We want to ensure that we're explicitly closing our file handler in download_attachment, so that we don't throw an error in cases where Python's garbage collector doesn't close the file.