### PR TITLE
For #36311: Adding playlist_code to SgTestConfig

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -309,7 +309,7 @@ class SgTestConfig(object):
             'api_key', 'asset_code', 'http_proxy', 'human_login', 'human_name',
             'human_password', 'mock', 'project_name', 'script_name', 
             'server_url', 'session_uuid', 'shot_code', 'task_content', 
-            'version_code'
+            'version_code', 'playlist_code'
         ]
 
     def read_config(self, config_path):


### PR DESCRIPTION
SgTestConfig is missing a reference to the playlist_code config.