### PR TITLE
For #34163, better import strategy for mimetypes

### DIFF
--- a/shotgun_api3/lib/mimetypes.py
+++ b/shotgun_api3/lib/mimetypes.py
@@ -242,28 +242,34 @@ class MimeTypes:
             i = 0
             while True:
                 try:
-                    yield _winreg.EnumKey(mimedb, i)
+                    ctype = _winreg.EnumKey(mimedb, i)
                 except EnvironmentError:
                     break
+                else:
+                    if '\0' not in ctype:
+                        yield ctype
                 i += 1
 
+        default_encoding = sys.getdefaultencoding()
         with _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, '') as hkcr:
             for subkeyname in enum_types(hkcr):
-                # Only check file extensions, not all possible classes
-                if not subkeyname.startswith("."):
-                    continue
-
-                with _winreg.OpenKey(hkcr, subkeyname) as subkey:
-                    # If there is no "Content Type" value, or if it is not
-                    # a simple string, simply skip
-                    try:
+                try:
+                    with _winreg.OpenKey(hkcr, subkeyname) as subkey:
+                        # Only check file extensions
+                        if not subkeyname.startswith("."):
+                            continue
+                        # raises EnvironmentError if no 'Content Type' value
                         mimetype, datatype = _winreg.QueryValueEx(
                             subkey, 'Content Type')
-                    except EnvironmentError:
-                        continue
-                    if datatype != _winreg.REG_SZ:
-                        continue
-                    self.add_type(mimetype, subkeyname, strict)
+                        if datatype != _winreg.REG_SZ:
+                            continue
+                        try:
+                            mimetype = mimetype.encode(default_encoding)
+                        except UnicodeEncodeError:
+                            continue
+                        self.add_type(mimetype, subkeyname, strict)
+                except EnvironmentError:
+                    continue
 
 def guess_type(url, strict=True):
     """Guess the type of a file based on its URL.

--- a/shotgun_api3/sg_26.py
+++ b/shotgun_api3/sg_26.py
@@ -35,7 +35,7 @@ def _is_mimetypes_broken():
     # mimetypes is broken on Windows only and for Python 2.7 to 2.7.7 inclusively.
     return (sys.platform == "win32" and
             sys.version_info[0] == 2 and sys.version_info[1] == 7 and
-            sys.version_info[2] >= 0 and sys.version_info[2] <= 7)
+            sys.version_info[2] >= 0 and sys.version_info[2] <= 6)
 
 if _is_mimetypes_broken():
     from .lib import mimetypes as mimetypes

--- a/shotgun_api3/sg_26.py
+++ b/shotgun_api3/sg_26.py
@@ -32,10 +32,15 @@ def _is_mimetypes_broken():
 
     :returns: True if the version of mimetypes is broken, False otherwise.
     """
-    # mimetypes is broken on Windows only and for Python 2.7 to 2.7.7 inclusively.
+    # mimetypes is broken on Windows only and for Python 2.7.0 to 2.7.9 inclusively.
+    # We're bundling the version from 2.7.10.
+    # See bugs :
+    # http://bugs.python.org/issue9291  <- Fixed in 2.7.7
+    # http://bugs.python.org/issue21652 <- Fixed in 2.7.8
+    # http://bugs.python.org/issue22028 <- Fixed in 2.7.10
     return (sys.platform == "win32" and
             sys.version_info[0] == 2 and sys.version_info[1] == 7 and
-            sys.version_info[2] >= 0 and sys.version_info[2] <= 6)
+            sys.version_info[2] >= 0 and sys.version_info[2] <= 9)
 
 if _is_mimetypes_broken():
     from .lib import mimetypes as mimetypes

--- a/shotgun_api3/sg_26.py
+++ b/shotgun_api3/sg_26.py
@@ -26,12 +26,18 @@ except ImportError:
         sys.path.pop()
 
 
-import mimetypes    # used for attachment upload
-try:
-    mimetypes.add_type('video/webm','.webm') # try adding to test for unicode error
-except (UnicodeDecodeError, TypeError):
-    # Ticket #25579: python bug on windows with unicode
-    # Ticket #23371: mimetypes initialization fails on Windows because of TypeError 
-    #               (http://bugs.python.org/issue23371)
-    # Use patched version of mimetypes
+def _is_mimetypes_broken():
+    """
+    Checks if this version of Python ships with a broken version of mimetypes
+
+    :returns: True if the version of mimetypes is broken, False otherwise.
+    """
+    # mimetypes is broken on Windows only and for Python 2.7 to 2.7.7 inclusively.
+    return (sys.platform == "win32" and
+            sys.version_info[0] == 2 and sys.version_info[1] == 7 and
+            sys.version_info[2] >= 0 and sys.version_info[2] <= 7)
+
+if _is_mimetypes_broken():
     from .lib import mimetypes as mimetypes
+else:
+    import mimetypes

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -415,7 +415,7 @@ class TestMimetypesFix(unittest.TestCase):
         Makes sure fix is imported for only for Python 2.7.0 to 2.7.7 on win32
         """
         self._test_mimetypes_import("win32", 2, 6, 9, False)
-        for patch in range(0, 8):
+        for patch in range(0, 7):
             self._test_mimetypes_import("win32", 2, 7, patch, True)
         self._test_mimetypes_import("win32", 2, 7, 8, False)
         self._test_mimetypes_import("win32", 3, 0, 0, False)

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -2,6 +2,7 @@
 import unittest
 from mock import patch, Mock
 import shotgun_api3 as api
+from shotgun_api3.sg_26 import _is_mimetypes_broken
 
 class TestShotgunInit(unittest.TestCase):
     '''Test case for Shotgun.__init__'''
@@ -393,13 +394,32 @@ class TestFilters(unittest.TestCase):
         
         self.assertRaises(api.ShotgunError, api.shotgun._translate_filters, filters, "all")
 
+
+class TestMimetypesFix(unittest.TestCase):
+    """
+    Makes sure that the mimetypes fix will be imported.
+    """
+
+    @patch('shotgun_api3.sg_26.sys')
+    def _test_mimetypes_import(self, platform, major, minor, patch, result, mock):
+        """
+        Mocks sys.platform and sys.version_info to test the mimetypes import code.
+        """
+
+        mock.version_info = [major, minor, patch]
+        mock.platform = platform
+        self.assertEqual(_is_mimetypes_broken(), result)
+
+    def test_correct_mimetypes_imported(self):
+        """
+        Makes sure fix is imported for only for Python 2.7.0 to 2.7.7 on win32
+        """
+        self._test_mimetypes_import("win32", 2, 6, 9, False)
+        for patch in range(0, 8):
+            self._test_mimetypes_import("win32", 2, 7, patch, True)
+        self._test_mimetypes_import("win32", 2, 7, 8, False)
+        self._test_mimetypes_import("win32", 3, 0, 0, False)
+        self._test_mimetypes_import("darwin", 2, 7, 0, False)
+
 if __name__ == '__main__':
     unittest.main()
-
-
-
-
-
-        
-        
-

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -415,9 +415,9 @@ class TestMimetypesFix(unittest.TestCase):
         Makes sure fix is imported for only for Python 2.7.0 to 2.7.7 on win32
         """
         self._test_mimetypes_import("win32", 2, 6, 9, False)
-        for patch in range(0, 7):
+        for patch in range(0, 10): # 0 to 9 inclusively
             self._test_mimetypes_import("win32", 2, 7, patch, True)
-        self._test_mimetypes_import("win32", 2, 7, 8, False)
+        self._test_mimetypes_import("win32", 2, 7, 10, False)
         self._test_mimetypes_import("win32", 3, 0, 0, False)
         self._test_mimetypes_import("darwin", 2, 7, 0, False)
 


### PR DESCRIPTION
We now always import the bundled `mimetypes`module on versions of Python that are broken.