### PR TITLE
For #37361: Updating config to randomize human user

### DIFF
--- a/tests/example_config
+++ b/tests/example_config
@@ -17,7 +17,6 @@ project_name   : SG unittest project
 
 human_name     : Sg unittest human
 human_login    : sgunittesthuman
-human_password : human password
 
 asset_code     : Sg unittest asset
 version_code   : Sg unittest version


### PR DESCRIPTION
Randomizing the human user account created when running tests, unless otherwise specified by an environment variable.