### PR TITLE
for #39129: catch empty files before uploading() and raise exception.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Here you can see the full list of changes between each Python API release.
 v3.0.33.dev (TBD)
 =================
 
+- Raise an exception when uploading an empty file using :meth:`upload`, :meth:`upload_thumbnail` 
+  or :meth:`upload_filmstrip_thumbnail` before calling out to the server.
 - TBD
 
 v3.0.32 (2016 Sep 22)

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2137,7 +2137,7 @@ class Shotgun(object):
 
         :param str entity_type: Entity type to link the upload to.
         :param int entity_id: Id of the entity to link the upload to.
-        :param str path: Full path to file on disk to upload.
+        :param str path: Full path to an existing non-empty file on disk to upload.
         :param str field_name: The internal Shotgun field name on the entity to store the file in.
             This field must be a File/Link field type.
         :param str display_name: The display name to use for the file. Defaults to the file name.
@@ -2145,9 +2145,13 @@ class Shotgun(object):
         :returns: Id of the Attachment entity that was created for the image.
         :rtype: int
         """
+        # Basic validations of the file to upload.
         path = os.path.abspath(os.path.expanduser(path or ""))
         if not os.path.isfile(path):
             raise ShotgunError("Path must be a valid file, got '%s'" % path)
+        if os.path.getsize(path) == 0:
+            raise ShotgunError("The file \"%s\" is empty. Please provide a non-empty file "
+                               "to upload" % path)
 
         is_thumbnail = (field_name in ["thumb_image", "filmstrip_thumb_image", "image",
                                        "filmstrip_image"])

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2150,8 +2150,7 @@ class Shotgun(object):
         if not os.path.isfile(path):
             raise ShotgunError("Path must be a valid file, got '%s'" % path)
         if os.path.getsize(path) == 0:
-            raise ShotgunError("The file \"%s\" is empty. Please provide a non-empty file "
-                               "to upload" % path)
+            raise ShotgunError("Path cannot be an empty file: '%s'" % path)
 
         is_thumbnail = (field_name in ["thumb_image", "filmstrip_thumb_image", "image",
                                        "filmstrip_image"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1629,6 +1629,27 @@ class TestErrors(base.TestBase):
         # except above wasn't properly run
         self.assertTrue(False)
 
+    def test_upload_empty_file(self):
+        """
+        Test uploading an empty file raises an error.
+        """
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.abspath(os.path.expanduser(os.path.join(this_dir,"empty.txt")))
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload, 'Version', 123, path)
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload_thumbnail, 'Version', 123, path)
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload_filmstrip_thumbnail, 'Version', 
+                          123, path)
+
+    def test_upload_missing_file(self):
+        """
+        Test uploading an missing file raises an error.
+        """
+        path = "/path/to/nowhere/foo.txt"
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload, 'Version', 123, path)
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload_thumbnail, 'Version', 123, path)
+        self.assertRaises(shotgun_api3.ShotgunError, self.sg.upload_filmstrip_thumbnail, 'Version', 
+                          123, path)
+
 #    def test_malformed_response(self):
 #        #TODO ResponseError
 #        pass


### PR DESCRIPTION
It was possible to attempt to upload a zero-byte file which can cause all sorts of issues but most notably it generates a ServerError which is misleading to the user. We now check the file exists and is not empty before calling `upload()`. If the file is empty, and exception is now raised stating the issue.