### PR TITLE
mockgun: add support of status_list

### DIFF
--- a/shotgun_api3/lib/mockgun.py
+++ b/shotgun_api3/lib/mockgun.py
@@ -526,6 +526,7 @@ class Shotgun(object):
                                    "serializable": dict,
                                    "date": datetime.date,
                                    "date_time": datetime.datetime,
+                                   "list": basestring,
                                    "status_list": basestring,
                                    "url": dict}[sg_type]
                 except KeyError:

--- a/shotgun_api3/lib/mockgun.py
+++ b/shotgun_api3/lib/mockgun.py
@@ -526,6 +526,7 @@ class Shotgun(object):
                                    "serializable": dict,
                                    "date": datetime.date,
                                    "date_time": datetime.datetime,
+                                   "status_list": basestring,
                                    "url": dict}[sg_type]
                 except KeyError:
                     raise ShotgunError("Field %s.%s: Handling for Shotgun type %s is not implemented" % (entity_type, field, sg_type)) 
@@ -587,7 +588,7 @@ class Shotgun(object):
                 return lval < rval[0] or lval > rval[1]
             elif operator == "in":
                 return lval in rval
-        elif field_type == "list":
+        elif field_type in ("list", "status_list"):
             if operator == "is":
                 return lval == rval
             elif operator == "is_not":


### PR DESCRIPTION
We faced the following warnings from mockgun when we tried to use the status_list on shots:

* `ShotgunError: The not_in operator is not supported on the status_list type` (fixed in `_compare`)
* `ShotgunError: Field Shot.sg_status_list: Handling for Shotgun type status_list is not implemented` (fixed in `_validate_entity_data`)

Let me know if it should be done another way.


Best,
Jordi

