### PR TITLE
Update v3.0.32 docs formatting

### DIFF
--- a/docs/cookbook/tasks/updating_tasks.rst
+++ b/docs/cookbook/tasks/updating_tasks.rst
@@ -45,14 +45,17 @@ will vary.
 
 .. note:: The ``duration`` field stores ``duration`` values in minutes
 
-Universal
-=========
+
+----
+
+.. rubric:: Universal
+
 Regardless of current values on the Task, this behavior rules::
 
     Task = {'start_date': '2011-05-20', 'due_date': '2011-05-25', 'duration': 2400, 'id':123}
 
-Update start_date and due_date
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Update start_date and due_date**
+
 ``duration`` is ignored if also provided. It is instead set automatically as (``due_date`` - 
 ``start_date``)
 
@@ -67,8 +70,7 @@ Update start_date and due_date
 
 .. note:: The value provided in the update() is ignored (and in this case was also incorrect).
 
-Update start_date and duration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Update start_date and duration**
 
 ::
 
@@ -79,8 +81,7 @@ Update start_date and duration
 - ``duration`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``).
 
-Update due_date and duration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Update due_date and duration**
 
 ::
 
@@ -93,15 +94,19 @@ Update due_date and duration
 
 .. note:: This means the ``duration`` provided is overwritten.
 
-Task has start_date only
-========================
+
+----
+
+.. rubric:: Task has start_date only
+
+If the Task only has a ``start_date`` value and has no other date values, this is how updates
+will behave.
 
 ::
 
     Task = {'start_date': '2011-05-20', 'due_date': None, 'duration': None, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -110,8 +115,7 @@ Update start_date
 
 - Only ``start_date`` is updated.
 
-Update due_date
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -121,8 +125,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``).
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -132,15 +135,19 @@ Update duration
 - ``duration`` is updated.
 - ``due_date`` is set to (``start_date`` + ``duration``)
 
-Task has due_date only
-======================
+
+----
+
+.. rubric:: Task has due_date only
+
+If the Task only has a ``due_date`` value and has no other date values, this is how updates
+will behave.
 
 ::
 
     # Task = {'start_date': None, 'due_date': '2011-05-25', 'duration': None, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -150,8 +157,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``).
 
-Update due_date 
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -160,8 +166,7 @@ Update due_date
 
 - only ``due_date`` is updated.
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -171,15 +176,19 @@ Update duration
 - ``duration`` is updated.
 - ``start_date`` is set to (``due_date`` - ``duration``)
 
-Task has duration only
-======================
+
+----
+
+.. rubric:: Task has duration only
+
+If the Task only has a ``duration`` value and has no other date values, this is how updates
+will behave.
 
 ::
 
     # Task = {'start_date': None, 'due_date': None, 'duration': 2400, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -189,8 +198,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``).
 
-Update due_date
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -200,8 +208,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``start_date`` is updated to (``due_date`` - ``duration``)
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -210,15 +217,19 @@ Update duration
 
 - only ``duration`` is updated.
 
-Task has start_date and due_date (no duration)
-==============================================
+
+----
+
+.. rubric:: Task has start_date and due_date
+
+If the Task has ``start_date`` and ``due_date`` values but has no ``duration``, this is how updates
+will behave.
 
 ::
     
     # Task = {'start_date': '2011-05-20', 'due_date': '2011-05-25', 'duration': None, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -228,8 +239,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``).
 
-Update due_date 
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -239,8 +249,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``)
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -250,15 +259,19 @@ Update duration
 - ``duration`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``)
 
-Task has start_date and duration (no due_date)
-==============================================
+
+----
+
+.. rubric:: Task has start_date and duration
+
+If the Task has ``start_date`` and ``duration`` values but has no ``due_date``, this is how updates
+will behave.
 
 ::
 
     # Task = {'start_date': '2011-05-20', 'due_date': None, 'duration': 2400, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -268,8 +281,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``due_date`` is updated to (``start_date`` +``duration``).
 
-Update due_date
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -279,8 +291,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``).
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -290,15 +301,19 @@ Update duration
 - ``duration`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``)
 
-Task has due_date and duration (no start_date)
-==============================================
+
+----
+
+.. rubric:: Task has due_date and duration
+
+If the Task has ``due_date`` and ``duration`` values but has no ``start_date``, this is how updates
+will behave.
 
 ::
     
     # Task = {'start_date': None, 'due_date': '2011-05-25', 'duration': 2400, 'id':123}
 
-Update start_date
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -308,8 +323,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``).
 
-Update due_date
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -319,8 +333,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``start_date`` is updated to (``due_date`` - ``duration``).
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 
@@ -330,15 +343,19 @@ Update duration
 - ``duration`` is updated.
 - ``start_date`` is updated to (``due_date`` - ``duration``)
 
-Task has start_date ,due_date, and duration
-===========================================
+
+----
+
+.. rubric:: Task has start_date ,due_date, and duration
+
+If the Task has ``start_date``, ``due_date``, and ``duration``, this is how updates
+will behave.
 
 ::
 
     # Task = {'start_date': '2011-05-20', 'due_date': '2011-05-25', 'duration': 2400, 'id':123}
 
-Update start_date 
-~~~~~~~~~~~~~~~~~
+**Update start_date**
 
 ::
 
@@ -348,8 +365,7 @@ Update start_date
 - ``start_date`` is updated.
 - ``due_date`` is updated to (``start_date`` + ``duration``).
 
-Update due_date
-~~~~~~~~~~~~~~~
+**Update due_date**
 
 ::
 
@@ -359,8 +375,7 @@ Update due_date
 - ``due_date`` is updated.
 - ``duration`` is updated to (``due_date`` - ``start_date``)
 
-Update duration
-~~~~~~~~~~~~~~~
+**Update duration**
 
 ::
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -20,14 +20,89 @@ class. There are a couple of useful attributes to note.
     :special-members:
 
 ***************
+Shotgun()
+***************
+
+.. autoclass:: Shotgun
+    :show-inheritance:
+
+***************
 Shotgun Methods
 ***************
 
 The majority of functionality is contained within the :class:`~shotgun_api3.Shotgun` class. 
 The documentation for all of the methods you'll need in your scripts lives in here.
 
-.. autoclass:: Shotgun
-    :show-inheritance:
+.. rubric:: Connection & Authentication
+
+.. autosummary:: 
+    :nosignatures:
+
+    Shotgun.connect
+    Shotgun.close
+    Shotgun.authenticate_human_user
+    Shotgun.get_session_token
+    Shotgun.set_up_auth_cookie
+    Shotgun.add_user_agent
+    Shotgun.reset_user_agent
+    Shotgun.set_session_uuid
+    Shotgun.info  
+
+.. rubric:: CRUD Methods
+
+.. autosummary:: 
+    :nosignatures:
+
+    Shotgun.create
+    Shotgun.find
+    Shotgun.find_one
+    Shotgun.update
+    Shotgun.delete
+    Shotgun.revive
+    Shotgun.batch
+    Shotgun.summarize
+    Shotgun.note_thread_read
+    Shotgun.text_search
+    Shotgun.update_project_last_accessed
+    Shotgun.work_schedule_read
+    Shotgun.work_schedule_update
+
+.. rubric:: Working With Files
+
+.. autosummary:: 
+    :nosignatures:
+
+    Shotgun.upload
+    Shotgun.upload_thumbnail
+    Shotgun.upload_filmstrip_thumbnail
+    Shotgun.download_attachment
+    Shotgun.get_attachment_download_url
+    Shotgun.share_thumbnail
+
+.. rubric:: Activity Stream
+
+.. autosummary:: 
+    :nosignatures:
+
+    Shotgun.activity_stream_read
+    Shotgun.follow
+    Shotgun.unfollow
+    Shotgun.followers
+
+.. rubric:: Working with the Shotgun Schema
+
+.. autosummary:: 
+    :nosignatures:
+
+    Shotgun.schema_entity_read
+    Shotgun.schema_field_read
+    Shotgun.schema_field_create
+    Shotgun.schema_field_update
+    Shotgun.schema_field_delete
+    Shotgun.schema_read
+    Shotgun.schema
+    Shotgun.entity_types
+
 
 Connection & Authentication
 ===========================


### PR DESCRIPTION
* Fixes the formatting in the `API Cookbook > Working With Tasks` section. The left nav TOC was wrapping all over the place and wonked out. This simplifies the TOC.

* Adds an index to the top of the API Reference section for `Shotgun()` to show a list of methods grouped by type.

*Note these docs are already published at http://developer.shotgunsoftware.com/python-api*. 