### PR TITLE
fix nested multi-entities query

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -114,7 +114,6 @@ Below is a non-exhaustive list of things that we still need to implement:
 
 """
 
-import copy
 import datetime
 
 from ... import sg_timezone, ShotgunError
@@ -301,7 +300,7 @@ class Shotgun(object):
             )
         ]
 
-        # Request additional fields from results
+        # Extract fields from row
         val = [dict((field, self._get_field_from_row(entity_type, row, field)) for field in all_fields) for row in results]
 
         # Handle the ordering of the result after we requested additional fields from results.
@@ -379,7 +378,9 @@ class Shotgun(object):
         
         self._update_row(entity_type, row, data)
         row["id"] = next_id
-        row["created_at"] = datetime.datetime.now()
+        
+        if "create_at" not in row:
+            row["created_at"] = datetime.datetime.now()
         
         self._db[entity_type][next_id] = row
         
@@ -655,11 +656,6 @@ class Shotgun(object):
                 # not multi entity, must be entity.
                 elif not isinstance(field_value, dict):
                     raise ShotgunError("Invalid deep query field %s.%s" % (entity_type, field))
-
-                # make sure that types in the query match type in the linked field
-                if entity_type2 != field_value["type"]:
-                    raise ShotgunError("Deep query field %s.%s does not match type "
-                                       "with data %s" % (entity_type, field, field_value))
 
                 # ok so looks like the value is an entity link
                 # e.g. db contains: {"sg_sequence": {"type":"Sequence", "id": 123 } }

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -379,7 +379,7 @@ class Shotgun(object):
         self._update_row(entity_type, row, data)
         row["id"] = next_id
         
-        if "create_at" not in row:
+        if "created_at" not in row:
             row["created_at"] = datetime.datetime.now()
         
         self._db[entity_type][next_id] = row


### PR DESCRIPTION
Hi, 

We started using mockgun for testing our pipeline at Squeeze.
However I've realized that some calls to find that worked with Shotgun failed with mockgun.
This was mainly related to :
- Using nested multi-entity when filtering (ex: ["project.Project.users.HumanUser.login", "is", "user1"])
- Requested fields (indirectly through the order argument) not being returned.

I've made the changes and implemented some additional tests, hope it help!