### PR TITLE
Fixes `is` and `is_not` comparison with `None` on multi entity fields

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -600,8 +600,12 @@ class Shotgun(object):
                 return lval["name"].endswith(rval)
         elif field_type == "multi_entity":
             if operator == "is":
+                if rval is None:
+                    return len(lval) == 0
                 return rval["id"] in (sub_lval["id"] for sub_lval in lval)
             elif operator == "is_not":
+                if rval is None:
+                    return len(lval) != 0
                 return rval["id"] not in (sub_lval["id"] for sub_lval in lval)
 
         raise ShotgunError("The %s operator is not supported on the %s type" % (operator, field_type))

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -269,6 +269,17 @@ class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):
         )
         self.assertEqual(len(items), 1)
 
+    def test_find_with_none(self):
+
+        items = self._mockgun.find("PipelineConfiguration", [["users", "is", None]], ["users"])
+        self.assertEqual(len(items), 1)
+        self.assertListEqual(items[0]["users"], [])
+
+        items = self._mockgun.find("PipelineConfiguration", [["users", "is_not", None]], ["users"])
+        self.assertEqual(len(items), 3)
+        for item in items:
+            self.assertTrue(len(item["users"]) > 0)
+
 
 class TestFilterOperator(TestBaseWithExceptionTests):
     """

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -275,7 +275,7 @@ class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):
         """
         items = self._mockgun.find("PipelineConfiguration", [["users", "is", None]], ["users"])
         self.assertEqual(len(items), 1)
-        self.assertListEqual(items[0]["users"], [])
+        self.assertEqual(items[0]["users"], [])
 
         items = self._mockgun.find("PipelineConfiguration", [["users", "is_not", None]], ["users"])
         self.assertEqual(len(items), 3)

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -270,7 +270,9 @@ class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):
         self.assertEqual(len(items), 1)
 
     def test_find_with_none(self):
-
+        """
+        Ensures comparison with multi-entity fields and None works.
+        """
         items = self._mockgun.find("PipelineConfiguration", [["users", "is", None]], ["users"])
         self.assertEqual(len(items), 1)
         self.assertListEqual(items[0]["users"], [])


### PR DESCRIPTION
Title says it all. :)