### PR TITLE
mockgun: review _update_row to add the case of date fields

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -773,8 +773,8 @@ class Shotgun(object):
         :param dict data: data to inject in the row.
         """
         cases = {
-            "multi_entity": lambda field: [{"type": item["type"], "id": item["id"]} for item in field],
-            "date": lambda field: field.strftime("%Y-%m-%d"),
+            "multi_entity": lambda field_: [{"type": item["type"], "id": item["id"]} for item in field_],
+            "date": lambda field_: field_.strftime("%Y-%m-%d"),
         }
 
         for field in data:

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -772,17 +772,12 @@ class Shotgun(object):
         :param dict row: current definition of the row.
         :param dict data: data to inject in the row.
         """
-        cases = {
-            "multi_entity": lambda field_: [{"type": item["type"], "id": item["id"]} for item in field_],
-            "date": lambda field_: field_.strftime("%Y-%m-%d"),
-        }
-
         for field in data:
             field_type = self._get_field_type(entity_type, field)
             if field_type == "entity" and data[field]:
                 row[field] = {"type": data[field]["type"], "id": data[field]["id"]}
-            elif field_type in cases:
-                row[field] = cases[field_type](data[field])
+            elif field_type == "multi_entity":
+                row[field] = [{"type": item["type"], "id": item["id"]} for item in data[field]]
             else:
                 row[field] = data[field]
 

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -462,7 +462,7 @@ class Shotgun(object):
                                    "checkbox": bool,
                                    "text": basestring,
                                    "serializable": dict,
-                                   "date": str,
+                                   "date": basestring,
                                    "date_time": datetime.datetime,
                                    "list": basestring,
                                    "status_list": basestring,

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -773,8 +773,8 @@ class Shotgun(object):
         :param dict data: data to inject in the row.
         """
         cases = {
-            "multi_entity": lambda data: [{"type": item["type"], "id": item["id"]} for item in data[field]],
-            "date": lambda data: data[field].strftime("%Y-%m-%d"),
+            "multi_entity": lambda field: [{"type": item["type"], "id": item["id"]} for item in field],
+            "date": lambda field: field.strftime("%Y-%m-%d"),
         }
 
         for field in data:
@@ -782,7 +782,7 @@ class Shotgun(object):
             if field_type == "entity" and data[field]:
                 row[field] = {"type": data[field]["type"], "id": data[field]["id"]}
             elif field_type in cases:
-                row[field] = cases[field_type](data)
+                row[field] = cases[field_type](data[field])
             else:
                 row[field] = data[field]
 

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -462,7 +462,7 @@ class Shotgun(object):
                                    "checkbox": bool,
                                    "text": basestring,
                                    "serializable": dict,
-                                   "date": datetime.date,
+                                   "date": str,
                                    "date_time": datetime.datetime,
                                    "list": basestring,
                                    "status_list": basestring,

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -38,6 +38,9 @@ and can be run on their own by typing "python test_mockgun.py".
 import re
 import os
 import unittest
+
+import datetime
+
 from shotgun_api3.lib.mockgun import Shotgun as Mockgun
 from shotgun_api3 import ShotgunError
 
@@ -198,6 +201,41 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         """
         item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
         self.assertTrue(item)
+
+class TestUpdateRow(TestBaseWithExceptionTests):
+    """Test Suite for the behavior of the method _update_row."""
+
+    def setUp(self):
+        """Test data"""
+        self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
+
+    def test_whenAnEntityWithDateFieldIsCreated_thenTheDateFieldIsStoredAsString(self):
+        """
+        Given the data for a date field is given as a data object
+        When the entity is created
+        Then the data is converted to string like in the api.
+        """
+        project = self._mockgun.create(
+            "Project", {"name": "Death Star", "start_date": datetime.date(1980, 4, 5)}
+        )
+        self.assertEqual(
+            "1980-04-05", project["start_date"], msg="At this stage, the date should have been to string."
+        )
+
+    def test_whenAnEntityWithDatetimeFieldIsCreated_thenTheDatetimeIsStoredAsDatetime(self):
+        """
+        Given the data for a datetime is given as datetime
+        When the entity is created
+        Then the data is kept as datetime.
+        """
+        datetime_ = datetime.datetime(1980, 4, 5, 12, 0)
+        project = self._mockgun.create(
+            "Project", {"name": "Death Star", "updated_at": datetime_}
+        )
+        self.assertEqual(
+            datetime_, project["updated_at"],
+            msg="A datetime should have been kept as a datetime."
+        )
 
 
 class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -202,27 +202,28 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
         self.assertTrue(item)
 
-class TestUpdateRow(TestBaseWithExceptionTests):
-    """Test Suite for the behavior of the method _update_row."""
+
+class TestDateDatetimeFields(TestBaseWithExceptionTests):
+    """Test Suite for the behavior of the fields date and datetime."""
 
     def setUp(self):
         """Test data"""
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
 
-    def test_whenAnEntityWithDateFieldIsCreated_thenTheDateFieldIsStoredAsString(self):
+    def test_dateDataAreStoredAsString(self):
         """
-        Given the data for a date field is given as a data object
+        Given the data for a date field is given as a string
         When the entity is created
-        Then the data is converted to string like in the api.
+        Then the data is stored as a string.
         """
         project = self._mockgun.create(
-            "Project", {"name": "Death Star", "start_date": datetime.date(1980, 4, 5)}
+            "Project", {"name": "Death Star", "start_date": "1980-04-05"}
         )
         self.assertEqual(
-            "1980-04-05", project["start_date"], msg="At this stage, the date should have been to string."
+            "1980-04-05", project["start_date"], msg="The date should stay a string."
         )
 
-    def test_whenAnEntityWithDatetimeFieldIsCreated_thenTheDatetimeIsStoredAsDatetime(self):
+    def test_datetimeDataAreStoredAsDatetime(self):
         """
         Given the data for a datetime is given as datetime
         When the entity is created
@@ -233,8 +234,7 @@ class TestUpdateRow(TestBaseWithExceptionTests):
             "Project", {"name": "Death Star", "updated_at": datetime_}
         )
         self.assertEqual(
-            datetime_, project["updated_at"],
-            msg="A datetime should have been kept as a datetime."
+            datetime_, project["updated_at"], msg="A datetime should have been kept as a datetime."
         )
 
 


### PR DESCRIPTION
* The official python API returns a string instead of the date object.
    This patch mimics the behavior
    Keep in mind the python API returns a datetime object in case of
    datetimes.
* Add docstring
* Set the cases outside to the logic.