### PR TITLE
For #46904, site wide tk-config-default2

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -641,6 +641,8 @@ class Shotgun(object):
                         sub_field_value = self._get_field_from_row(entity_type2, entity, field3)
                         values.append(sub_field_value)
                     return values
+                elif field_value is None:
+                    return None
                 # not multi entity, must be entity.
                 elif not isinstance(field_value, dict):
                     raise ShotgunError("Invalid deep query field %s.%s" % (entity_type, field))

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -245,9 +245,8 @@ class Shotgun(object):
             return dict((k, v) for k, v in self._schema[entity_type].items() if k == field_name)
 
     def find(
-        self,
-        entity_type, filters, fields=None,
-        order=None, filter_operator=None, limit=0, retired_only=False, page=0
+        self, entity_type, filters, fields=None, order=None, filter_operator=None,
+        limit=0, retired_only=False, page=0
     ):
 
         self.finds += 1
@@ -317,9 +316,8 @@ class Shotgun(object):
         return val
 
     def find_one(
-        self,
-        entity_type, filters, fields=None,
-        order=None, filter_operator=None, retired_only=False
+        self, entity_type, filters, fields=None, order=None, filter_operator=None,
+        retired_only=False
     ):
         results = self.find(
             entity_type, filters, fields=fields,

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -188,6 +188,7 @@ class TestEntityFieldComparison(TestBaseWithExceptionTests):
         # it to not be returned here.
         items = self._mockgun.find("PipelineConfiguration", [["project.Project.archived", "is", False]])
         self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["id"], self._project_link["id"])
 
 
 class TestTextFieldOperators(TestBaseWithExceptionTests):

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -148,12 +148,12 @@ class TestEntityFieldComparison(TestBaseWithExceptionTests):
         """
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
 
-        self._project_link = self._mockgun.create("Project", {"name": "project"})
+        self._project_link = self._mockgun.create("Project", {"name": "project", "archived": False})
 
         # This entity will ensure that a populated link field will be comparable.
         self._mockgun.create(
             "PipelineConfiguration",
-            {"code": "with_project", "project": self._project_link}
+            {"code": "with_project", "project": self._project_link, }
         )
 
         # This entity will ensure that an unpopulated link field will be comparable.
@@ -178,6 +178,15 @@ class TestEntityFieldComparison(TestBaseWithExceptionTests):
         self.assertEqual(len(items), 1)
 
         items = self._mockgun.find("PipelineConfiguration", [["project", "is_not", self._project_link]])
+        self.assertEqual(len(items), 1)
+
+    def test_find_entity_with_none_link(self):
+        """
+        Make sure that we can search for sub entity fields on entities that have the field not set.
+        """
+        # The pipeline configuration without_project doesn't have the project field set, so we're expecting
+        # it to not be returned here.
+        items = self._mockgun.find("PipelineConfiguration", [["project.Project.archived", "is", False]])
         self.assertEqual(len(items), 1)
 
 


### PR DESCRIPTION
While writing unit tests in Toolkit I stumbled upon this bug, where searching for a sub-entity field would crash if any of the sub-entity field was set to `None`. See unit test for more info.

Also, PEP8ed `mockgun.py`. The actual fix [is on line 679](https://github.com/shotgunsoftware/python-api/pull/172/files#diff-443157c398f7038db0d1eb0401aa7d4eR679)