### PR TITLE
Ensures the password is properly unquoted for the test

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ need a live server to run against."""
 
 import base64
 import datetime
+import urllib
 import re
 try:
     import simplejson as json
@@ -147,7 +148,7 @@ class TestShotgunClient(base.MockTestBase):
         # login:password@domain
         auth_url = "%s%s@%s" % (self.uri_prefix, login_password, self.domain)
         sg = api.Shotgun(auth_url, None, None, connect=False)
-        expected = "Basic " + base64.encodestring(login_password).strip()
+        expected = "Basic " + base64.encodestring(urllib.unquote(login_password)).strip()
         self.assertEqual(expected, sg.config.authorization)
 
     def test_authorization(self):
@@ -167,7 +168,7 @@ class TestShotgunClient(base.MockTestBase):
         args, _ = self.sg._http_request.call_args
         verb, path, body, headers = args
 
-        expected = "Basic " + base64.encodestring(login_password).strip()
+        expected = "Basic " + base64.encodestring(urllib.unquote(login_password)).strip()
         self.assertEqual(expected, headers.get("Authorization"))
 
     def test_user_agent(self):


### PR DESCRIPTION
When using URL based authentication, the authorization header is being unquoted. If your test user has `%` in it's password, the test would fail.