### PR TITLE
SG-6892 - Use s3_enabled_upload_types for cloud uploads

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2280,7 +2280,7 @@ class Shotgun(object):
         supported_s3_types = self.server_info.get('s3_enabled_upload_types', {})
         if self.server_info.get("s3_direct_uploads_enabled", False) \
                 and field_name in supported_s3_types.get(entity_type, []):
-             return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
+            return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
                                            tag_list, is_thumbnail)
         else:
             return self._upload_to_sg(entity_type, entity_id, path, field_name, display_name,

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2278,8 +2278,12 @@ class Shotgun(object):
 
         # Supported types can be directly uploaded to Cloud storage
         supported_s3_types = self.server_info.get('s3_enabled_upload_types', {})
+        supported_fields = supported_s3_types.get(entity_type, [])
         if self.server_info.get("s3_direct_uploads_enabled", False) \
-                and field_name in supported_s3_types.get(entity_type, []):
+                and (field_name in supported_fields or
+                        field_name in supported_s3_types.get("*", []) or
+                        (isinstance(supported_fields, list) and "*" in supported_fields) or
+                            supported_fields == "*"):
             return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
                                            tag_list, is_thumbnail)
         else:

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2276,11 +2276,11 @@ class Shotgun(object):
         is_thumbnail = (field_name in ["thumb_image", "filmstrip_thumb_image", "image",
                                        "filmstrip_image"])
 
-        # Version.sg_uploaded_movie is handled as a special case and uploaded
-        # directly to Cloud storage
+        # Supported types can be directly uploaded to Cloud storage
+        supported_s3_types = self.server_info.get('s3_enabled_upload_types', {})
         if self.server_info.get("s3_direct_uploads_enabled", False) \
-                and entity_type == "Version" and field_name == "sg_uploaded_movie":
-            return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
+                and field_name in supported_s3_types[entity_type]:
+             return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
                                            tag_list, is_thumbnail)
         else:
             return self._upload_to_sg(entity_type, entity_id, path, field_name, display_name,

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2279,7 +2279,7 @@ class Shotgun(object):
         # Supported types can be directly uploaded to Cloud storage
         supported_s3_types = self.server_info.get('s3_enabled_upload_types', {})
         if self.server_info.get("s3_direct_uploads_enabled", False) \
-                and field_name in supported_s3_types[entity_type]:
+                and field_name in supported_s3_types.get(entity_type, []):
              return self._upload_to_storage(entity_type, entity_id, path, field_name, display_name,
                                            tag_list, is_thumbnail)
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -424,7 +424,6 @@ class TestShotgunApi(base.LiveTestBase):
         self.sg.server_info["s3_enabled_upload_types"] = None
         self.sg.server_info["s3_direct_uploads_enabled"] = None
 
-
         # Test s3_enabled_upload_types and s3_direct_uploads_enabled not set
         self.assertFalse(self.sg._requires_direct_s3_upload("Version", "sg_uploaded_movie"))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,8 +418,8 @@ class TestShotgunApi(base.LiveTestBase):
     def test_requires_direct_s3_upload(self):
         """Test _requires_direct_s3_upload"""
 
-        upload_types = self.sg.server_info["s3_enabled_upload_types"]
-        direct_uploads_enabled = self.sg.server_info["s3_direct_uploads_enabled"]
+        upload_types = self.sg.server_info.get("s3_enabled_upload_types")
+        direct_uploads_enabled = self.sg.server_info.get("s3_direct_uploads_enabled")
 
         self.sg.server_info["s3_enabled_upload_types"] = None
         self.sg.server_info["s3_direct_uploads_enabled"] = None


### PR DESCRIPTION
Makes use of the new `s3_enabled_upload_types` info object to see if an upload supports and should be sent to cloud storage.