### PR TITLE
Use ProxyHandler for uploads when using proxy elsewhere

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3811,9 +3811,7 @@ class Shotgun(object):
         """
         try:
             if self.config.raw_http_proxy is not None:
-                handler = urllib2.ProxyHandler(
-                              {'https': self.config.raw_http_proxy}
-                          )
+                handler = urllib2.ProxyHandler({'https': self.config.raw_http_proxy})
             else:
                 handler = urllib2.HTTPHandler
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3810,7 +3810,14 @@ class Shotgun(object):
         :rtype: str
         """
         try:
-            opener = urllib2.build_opener(urllib2.HTTPHandler)
+            if self.config.raw_http_proxy is not None:
+                handler = urllib2.ProxyHandler(
+                                        {'https': self.config.raw_http_proxy}
+                                        )
+            else:
+                handler = urllib2.HTTPHandler
+
+            opener = urllib2.build_opener(handler)
 
             request = urllib2.Request(storage_url, data=data)
             request.add_header("Content-Type", content_type)

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3812,8 +3812,8 @@ class Shotgun(object):
         try:
             if self.config.raw_http_proxy is not None:
                 handler = urllib2.ProxyHandler(
-                                        {'https': self.config.raw_http_proxy}
-                                        )
+                              {'https': self.config.raw_http_proxy}
+                          )
             else:
                 handler = urllib2.HTTPHandler
 


### PR DESCRIPTION
To avoid having to use the `http_proxy` environment variable when uploading files behind a proxy, this patch creates a ProxyHandler rather than a HTTPHandler when the `self.config.raw_http_proxy` is set.