### PR TITLE
Added mockgun support for "not_in" operator when using text fields

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -607,6 +607,8 @@ class Shotgun(object):
                 return lval.startswith(rval)
             elif operator == "ends_with":
                 return lval.endswith(rval)
+            elif operator == "not_in":
+                return lval not in rval
         elif field_type == "entity":
             if operator == "is":
                 # If one of the two is None, ensure both are.


### PR DESCRIPTION
This is to match the filters with the regular api version, for cases like this:
sg.find_one('Version', [ **['code', 'not_in', ['Hello Mockgun World !']** ]], ['description'])