### PR TITLE
Allow unverified SSL

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -324,6 +324,11 @@ class ClientCapabilities(object):
         # extract the OpenSSL version if we can. The version is only available in Python 2.7 and
         # only if we successfully imported ssl
         self.ssl_version = "unknown"
+
+        # -- This is the way to allow unverified SSL
+        if NO_SSL_VALIDATION: 
+            ssl._create_default_https_context = ssl._create_unverified_context
+
         try:
             self.ssl_version = ssl.OPENSSL_VERSION
         except (AttributeError, NameError):


### PR DESCRIPTION
This is about SSL Validation support.
It is little bit more expanded code than #149

Current SG API version can not upload version's path to movie when SSL certificate verify is failed.
Adding the option 'NO_SSL_VALIDATION = True' also results in the same.
Errors that occur are as follows.
`urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)>`

So, I added code about create a new SSL Context code for bypass verification.

Thanks.