### PR TITLE
Adding the following method to the documentation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -89,6 +89,7 @@ The documentation for all of the methods you'll need in your scripts lives in he
     Shotgun.follow
     Shotgun.unfollow
     Shotgun.followers
+    Shotgun.following
 
 .. rubric:: Working with the Shotgun Schema and Preferences
 
@@ -166,6 +167,7 @@ Methods that relate to the activity stream and following of entities in Shotgun.
 .. automethod:: Shotgun.follow
 .. automethod:: Shotgun.unfollow
 .. automethod:: Shotgun.followers
+.. automethod:: Shotgun.following
 
 Working with the Shotgun Schema
 ===============================


### PR DESCRIPTION
Aleksandar Kocic (koaleksa) pointed out that we don't have documentation for the following method in our Python API docs:
https://community.shotgunsoftware.com/t/undocumented-shotgun-api-method-shotgun-following-entity/644

This change adds that documentation.