### PR TITLE
SG-10151: set field visibility via API

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1996,7 +1996,7 @@ class Shotgun(object):
 
         return self._call_rpc("schema_field_create", params)
 
-    def schema_field_update(self, entity_type, field_name, properties):
+    def schema_field_update(self, entity_type, field_name, properties, project_entity=None):
         """
         Update the properties for the specified field on an entity.
 
@@ -2014,6 +2014,12 @@ class Shotgun(object):
         :param field_name: Internal Shotgun name of the field to update.
         :param properties: Dictionary with key/value pairs where the key is the property to be
             updated and the value is the new value.
+        :param dict project_entity: Optional Project entity specifying which project to modify the
+            ``visible`` property for. If the ``visible`` is present in ``properties`` and
+            ``project_entity`` is not set, an exception will be raised. Example:
+            ``{'type': 'Project', 'id': 3}``
+        :param project_entity: Link to the project we wish to change the field visibility for.
+            This is necessary only when updating the ``visible`` property of a field.
         :returns: ``True`` if the field was updated.
         :rtype: bool
         """
@@ -2026,7 +2032,7 @@ class Shotgun(object):
                 for k, v in six.iteritems((properties or {}))
             ]
         }
-
+        params = self._add_project_param(params, project_entity)
         return self._call_rpc("schema_field_update", params)
 
     def schema_field_delete(self, entity_type, field_name):

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2018,9 +2018,12 @@ class Shotgun(object):
             ``visible`` property for. If the ``visible`` is present in ``properties`` and
             ``project_entity`` is not set, an exception will be raised. Example:
             ``{'type': 'Project', 'id': 3}``
-        :param project_entity: Link to the project we wish to change the field visibility for.
-            This is necessary only when updating the ``visible`` property of a field.
         :returns: ``True`` if the field was updated.
+
+        .. note::
+            The ``project_entity`` parameter can only affect the state of the ``visible`` property
+            and has no impact on other properties.
+
         :rtype: bool
         """
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2714,7 +2714,7 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
             self.sg.schema_field_read("Asset", field_name, project_2)[field_name]["visible"]
         )
 
-        # Built-in fields should remain now editable.
+        # Built-in fields should remain not editable.
         self.assertFalse(self.sg.schema_field_read("Asset", "code")["code"]["visible"]["editable"])
 
         # Custom fields should be editable
@@ -2725,7 +2725,7 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
 
         # Hide the field on project 1
         self.sg.schema_field_update("Asset", field_name, {"visible": False}, project_1)
-        # If should not be visible anymore.
+        # It should not be visible anymore.
         self.assertEqual(
             {"value": False, "editable": True},
             self.sg.schema_field_read("Asset", field_name, project_1)[field_name]["visible"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2745,7 +2745,6 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
         )
 
 
-
 def _has_unicode(data):
     for k, v in data.items():
         if isinstance(k, six.text_type):


### PR DESCRIPTION
Adds support for updating field visibility through the API.

This can be achieved by the following code:

```python
sg.schema_field_update("Asset", "sg_my_custom_field", {"visible": False}, project)
```

where `project` is a dictionary referring to project in which we want to hide "sg_my_custom_field". Restoring visibility can be done via

```python
sg.schema_field_update("Asset", "sg_my_custom_field", {"visible": True}, project)
```

Note: The build is currently failing because the feature hasn't been released in Shotgun. Once the feature is released the test will be updated to the right version check and the feature commited.