### PR TITLE
SG-13267: Config fixes for Mockgun

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -193,6 +193,8 @@ class Shotgun(object):
         # they way they would expect to in the real API.
         self.config = _Config(self)
 
+        self.config.set_server_params(base_url)
+
         # load in the shotgun schema to associate with this Shotgun
         (schema_path, schema_entity_path) = self.get_schema_paths()
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -2054,7 +2054,7 @@ class Shotgun(object):
         :param properties: Dictionary with key/value pairs where the key is the property to be
             updated and the value is the new value.
         :param dict project_entity: Optional Project entity specifying which project to modify the
-            ``visible`` property for. If the ``visible`` is present in ``properties`` and
+            ``visible`` property for. If ``visible`` is present in ``properties`` and
             ``project_entity`` is not set, an exception will be raised. Example:
             ``{'type': 'Project', 'id': 3}``
         :returns: ``True`` if the field was updated.

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -443,8 +443,8 @@ class TestConfig(unittest.TestCase):
         Make sure it works with a normal URL.
         """
         mockgun = Mockgun("https://server.shotgunstudio.com/")
-        self.assertEqual(mockgun.config.scheme,  "https")
-        self.assertEqual(mockgun.config.server,  "server.shotgunstudio.com")
+        self.assertEqual(mockgun.config.scheme, "https")
+        self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
         self.assertEqual(mockgun.config.api_path, "/api3/json")
         self.assertIsNone(mockgun.config.authorization)
 
@@ -453,8 +453,8 @@ class TestConfig(unittest.TestCase):
         Make sure it works with a URL with a path
         """
         mockgun = Mockgun("https://local/something/")
-        self.assertEqual(mockgun.config.scheme,  "https")
-        self.assertEqual(mockgun.config.server,  "local")
+        self.assertEqual(mockgun.config.scheme, "https")
+        self.assertEqual(mockgun.config.server, "local")
         self.assertEqual(mockgun.config.api_path, "/something/api3/json")
         self.assertIsNone(mockgun.config.authorization)
 
@@ -463,8 +463,8 @@ class TestConfig(unittest.TestCase):
         Make sure it works with a URL than has some auth parameter.
         """
         mockgun = Mockgun("https://user:pass@server.shotgunstudio.com/")
-        self.assertEqual(mockgun.config.scheme,  "https")
-        self.assertEqual(mockgun.config.server,  "server.shotgunstudio.com")
+        self.assertEqual(mockgun.config.scheme, "https")
+        self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
         self.assertEqual(mockgun.config.api_path, "/api3/json")
         self.assertIsNotNone(mockgun.config.authorization)
 

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -433,5 +433,41 @@ class TestFilterOperator(TestBaseWithExceptionTests):
         )
 
 
+class TestConfig(unittest.TestCase):
+    """
+    Tests the shotgun._Config class
+    """
+
+    def test_set_server_params_with_regular_url(self):
+        """
+        Make sure it works with a normal URL.
+        """
+        mockgun = Mockgun("https://server.shotgunstudio.com/")
+        self.assertEqual(mockgun.config.scheme,  "https")
+        self.assertEqual(mockgun.config.server,  "server.shotgunstudio.com")
+        self.assertEqual(mockgun.config.api_path, "/api3/json")
+        self.assertIsNone(mockgun.config.authorization)
+
+    def test_set_server_params_with_url_with_path(self):
+        """
+        Make sure it works with a URL with a path
+        """
+        mockgun = Mockgun("https://local/something/")
+        self.assertEqual(mockgun.config.scheme,  "https")
+        self.assertEqual(mockgun.config.server,  "local")
+        self.assertEqual(mockgun.config.api_path, "/something/api3/json")
+        self.assertIsNone(mockgun.config.authorization)
+
+    def test_set_server_with_basic_auth(self):
+        """
+        Make sure it works with a URL than has some auth parameter.
+        """
+        mockgun = Mockgun("https://user:pass@server.shotgunstudio.com/")
+        self.assertEqual(mockgun.config.scheme,  "https")
+        self.assertEqual(mockgun.config.server,  "server.shotgunstudio.com")
+        self.assertEqual(mockgun.config.api_path, "/api3/json")
+        self.assertIsNotNone(mockgun.config.authorization)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -446,7 +446,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mockgun.config.scheme, "https")
         self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
         self.assertEqual(mockgun.config.api_path, "/api3/json")
-        self.assertIsNone(mockgun.config.authorization)
+        self.assertEqual(mockgun.config.authorization, None)
 
     def test_set_server_params_with_url_with_path(self):
         """
@@ -456,7 +456,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mockgun.config.scheme, "https")
         self.assertEqual(mockgun.config.server, "local")
         self.assertEqual(mockgun.config.api_path, "/something/api3/json")
-        self.assertIsNone(mockgun.config.authorization)
+        self.assertEqual(mockgun.config.authorization, None)
 
     def test_set_server_with_basic_auth(self):
         """
@@ -466,7 +466,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mockgun.config.scheme, "https")
         self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
         self.assertEqual(mockgun.config.api_path, "/api3/json")
-        self.assertIsNotNone(mockgun.config.authorization)
+        self.assertNotEqual(mockgun.config.authorization, None)
 
 
 if __name__ == '__main__':

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -446,7 +446,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mockgun.config.scheme, "https")
         self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
         self.assertEqual(mockgun.config.api_path, "/api3/json")
-        self.assertEqual(mockgun.config.authorization, None)
 
     def test_set_server_params_with_url_with_path(self):
         """
@@ -456,17 +455,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mockgun.config.scheme, "https")
         self.assertEqual(mockgun.config.server, "local")
         self.assertEqual(mockgun.config.api_path, "/something/api3/json")
-        self.assertEqual(mockgun.config.authorization, None)
-
-    def test_set_server_with_basic_auth(self):
-        """
-        Make sure it works with a URL than has some auth parameter.
-        """
-        mockgun = Mockgun("https://user:pass@server.shotgunstudio.com/")
-        self.assertEqual(mockgun.config.scheme, "https")
-        self.assertEqual(mockgun.config.server, "server.shotgunstudio.com")
-        self.assertEqual(mockgun.config.api_path, "/api3/json")
-        self.assertNotEqual(mockgun.config.authorization, None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Mockgun never initialized the values inside the `_Config` instance, which is causing some issues in Python 3 because of `None` values being passed into `urllib` methods.

I've added the required tests.