### PR TITLE
SG-37203 [Mockgun] Ensure string comparison are case insensitive

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -596,12 +596,21 @@ class Shotgun(object):
             if operator == "is":
                 return lval == rval
         elif field_type == "text":
+            # Some operations expect a list but can deal with a single value
+            if operator in ("in", "not_in") and not isinstance(rval, list):
+                rval = [rval]
+
+            # Some operation expect a string but can deal with None
+            elif operator in ("starts_with", "ends_with", "contains", "not_contains"):
+                lval = lval or ''
+                rval = rval or ''
+
             # Shotgun string comparison is case insensitive
-            lval = lval.lower()
+            lval = lval.lower() if lval is not None else None
             if isinstance(rval, list):
-                rval = [val.lower() for val in rval]
-            elif isinstance(rval, six.string_types):
-                rval = rval.lower()
+                rval = [val.lower() if val is not None else None for val in rval]
+            else:
+                rval = rval.lower() if rval is not None else None
 
             if operator == "is":
                 return lval == rval
@@ -612,7 +621,7 @@ class Shotgun(object):
             elif operator == "contains":
                 return rval in lval
             elif operator == "not_contains":
-                return lval not in rval
+                return rval not in lval
             elif operator == "starts_with":
                 return lval.startswith(rval)
             elif operator == "ends_with":

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -596,6 +596,13 @@ class Shotgun(object):
             if operator == "is":
                 return lval == rval
         elif field_type == "text":
+            # Shotgun string comparison is case insensitive
+            lval = lval.lower()
+            if isinstance(rval, list):
+                rval = [val.lower() for val in rval]
+            elif isinstance(rval, six.string_types):
+                rval = rval.lower()
+
             if operator == "is":
                 return lval == rval
             elif operator == "is_not":

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -202,11 +202,116 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
         self._user = self._mockgun.create("HumanUser", {"login": "user"})
 
+    def test_operator_is(self):
+        """
+        Ensure is operator work.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is", "user"]])
+        self.assertTrue(item)
+
+    def test_operator_is_case_sensitivity(self):
+        """
+        Ensure is operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is", "USER"]])
+        self.assertTrue(item)
+
+    def test_operator_is_not(self):
+        """
+        Ensure the is_not operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "another_user"]])
+        self.assertTrue(item)
+
+    def test_operator_is_not_case_sensitivity(self):
+        """
+        Ensure the is_not operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "USER"]])
+        self.assertFalse(item)
+
+    def test_operator_in(self):
+        """
+        Ensure the in operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "in", ["user"]]])
+        self.assertTrue(item)
+
+    def test_operator_in_case_sensitivity(self):
+        """
+        Ensure the in operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "in", ["USER"]]])
+        self.assertTrue(item)
+
+    def test_operator_not_in(self):
+        """
+        Ensure the not_in operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["foo"]]])
+        self.assertTrue(item)
+
+    def test_operator_not_in_case_sensitivity(self):
+        """
+        Ensure not_in operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["USER"]]])
+        self.assertFalse(item)
+
     def test_operator_contains(self):
         """
         Ensures contains operator works.
         """
         item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
+        self.assertTrue(item)
+
+    def test_operator_contains_case_sensitivity(self):
+        """
+        Ensure contains operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "contains", "SE"]])
+        self.assertTrue(item)
+
+    def test_operator_not_contains(self):
+        """
+        Ensure not_contains operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "foo"]])
+        self.assertTrue(item)
+
+    def test_operator_not_contains_case_sensitivity(self):
+        """
+        Ensure not_contains operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "USER"]])
+        self.assertFalse(item)
+
+    def test_operator_starts_with(self):
+        """
+        Ensure starts_with operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "us"]])
+        self.assertTrue(item)
+
+    def test_operator_starts_with_case_sensitivity(self):
+        """
+        Ensure starts_with operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "US"]])
+        self.assertTrue(item)
+
+    def test_operator_ends_with(self):
+        """
+        Ensure ends_with operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "er"]])
+        self.assertTrue(item)
+
+    def test_operator_ends_with_case_sensitivity(self):
+        """
+        Ensure starts_with operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "ER"]])
         self.assertTrue(item)
 
 

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -200,119 +200,175 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         Creates test data.
         """
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
-        self._user = self._mockgun.create("HumanUser", {"login": "user"})
+        self._user1 = self._mockgun.create("HumanUser", {"login": "user"})
+        self._user2 = self._mockgun.create("HumanUser", {"login": None})
 
     def test_operator_is(self):
         """
         Ensure is operator work.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is", "user"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is", "user"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_is_none(self):
+        """
+        Ensure is operator work when used with None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "is", None]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_case_sensitivity(self):
         """
         Ensure is operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is", "USER"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is", "USER"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_not(self):
         """
         Ensure the is_not operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "another_user"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", "user"]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_is_not_none(self):
+        """
+        Ensure the is_not operator works when used with None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", None]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_not_case_sensitivity(self):
         """
         Ensure the is_not operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "USER"]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", "USER"]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_in(self):
         """
         Ensure the in operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "in", ["user"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "in", ["user"]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_in_none(self):
+        """
+        Ensure the in operator works with a list containing None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "in", [None]]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_in_case_sensitivity(self):
         """
         Ensure the in operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "in", ["USER"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "in", ["USER"]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_in(self):
         """
         Ensure the not_in operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["foo"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", ["foo"]]])
+        expected = [
+            {"type": "HumanUser", "id": self._user1["id"]},
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_operator_not_in_none(self):
+        """
+        Ensure the not_not operator works with a list containing None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", [None]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_in_case_sensitivity(self):
         """
-        Ensure not_in operator is case insensitive.
+        Ensure the not_in operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["USER"]]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", ["USER"]]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_contains(self):
         """
-        Ensures contains operator works.
+        Ensures the contains operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "contains", "se"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_contains_case_sensitivity(self):
         """
-        Ensure contains operator is case insensitive.
+        Ensure the contains operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "contains", "SE"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "contains", "SE"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_contains(self):
         """
-        Ensure not_contains operator works.
+        Ensure the not_contains operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "foo"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_contains", "user"]])
+        expected = [
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_contains_case_sensitivity(self):
         """
-        Ensure not_contains operator is case insensitive.
+        Ensure the not_contains operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "USER"]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_contains", "USER"]])
+        expected = [
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
 
     def test_operator_starts_with(self):
         """
-        Ensure starts_with operator works.
+        Ensure the starts_with operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "us"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "starts_with", "us"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_starts_with_case_sensitivity(self):
         """
-        Ensure starts_with operator is case insensitive.
+        Ensure the starts_with operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "US"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "starts_with", "US"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_ends_with(self):
         """
-        Ensure ends_with operator works.
+        Ensure the ends_with operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "er"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "ends_with", "er"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_ends_with_case_sensitivity(self):
         """
-        Ensure starts_with operator is case insensitive.
+        Ensure the starts_with operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "ER"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "ends_with", "ER"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
 
 class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):


### PR DESCRIPTION
Hi!

We recently realized that for text field comparisons, Mockgun was case sensitive where a real Shotgun instance was always case insensitive. 

This seemed standard behavior so I updated Mockgun to match.
I've also added appropriate tests and new ones to increase text field comparison test coverage.

Let me know what you think. 

