### PR TITLE
SG-13264 Update sgsix, fix httplib2 import

### DIFF
--- a/shotgun_api3/lib/httplib2/__init__.py
+++ b/shotgun_api3/lib/httplib2/__init__.py
@@ -37,7 +37,3 @@ del __name
 
 # Add ssl_error_classes to __all__
 __all__.append('ssl_error_classes')
-
-
-# try to import stuff in certs
-# merge this WIP into tk-core -- one last warning need new six to get rid of

--- a/shotgun_api3/lib/httplib2/__init__.py
+++ b/shotgun_api3/lib/httplib2/__init__.py
@@ -36,4 +36,4 @@ del __httplib2_compat
 del __name
 
 # Add ssl_error_classes to __all__
-__all__.append('ssl_error_classes')
+__all__.append("ssl_error_classes")

--- a/shotgun_api3/lib/httplib2/__init__.py
+++ b/shotgun_api3/lib/httplib2/__init__.py
@@ -1,16 +1,43 @@
 from .. import six
 
-# import the proper implementation into the module namespace depending on the
+# Define all here to keep linters happy.  It should be overwritten by the code
+# below, but if in the future __all__ is not defined in httplib2 this will keep
+# things from breaking.
+__all__ = []
+
+# Import the proper implementation into the module namespace depending on the
 # current python version.  httplib2 supports python 2/3 by forking the code rather
 # than with a single cross-compatible module. Rather than modify third party code,
 # we'll just import the appropriate branch here.
 if six.PY3:
-    from .python3 import *
-    from .python3 import socks  # ensure include in namespace
-    import ssl
-    ssl_error_classes = (ssl.SSLError, ssl.CertificateError)
+    # Generate ssl_error_classes
+    import ssl as __ssl
+    ssl_error_classes = (__ssl.SSLError, __ssl.CertificateError)
+    del __ssl
+
+    # get the python3 fork of httplib2
+    from . import python3 as __httplib2_compat
+
+
 else:
-    from .python2 import *
-    from .python2 import socks  # ensure include in namespace
-    from .python2 import SSLHandshakeError  # TODO: shouldn't rely on this. not public
-    ssl_error_classes = (SSLHandshakeError,)
+    # Generate ssl_error_classes
+    from .python2 import SSLHandshakeError as __SSLHandshakeError  # TODO: shouldn't rely on this. not public
+    ssl_error_classes = (__SSLHandshakeError,)
+    del __SSLHandshakeError
+
+    # get the python2 fork of httplib2
+    from . import python2 as __httplib2_compat
+
+# Import all of the httplib2 module.  Note that we can't use a star import because
+# we need to import *everything*, not just what exists in __all__.
+for __name in dir(__httplib2_compat):
+    globals()[__name] = getattr(__httplib2_compat, __name)
+del __httplib2_compat
+del __name
+
+# Add ssl_error_classes to __all__
+__all__.append('ssl_error_classes')
+
+
+# try to import stuff in certs
+# merge this WIP into tk-core -- one last warning need new six to get rid of

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -57,9 +57,25 @@ else:
     from .httplib2 import SSLHandshakeError
     ShotgunSSLError = SSLHandshakeError
 
-# On Python 2 on linux hosts, sys.platform was 'linux' appended with the
-# current kernel version that Python was built on.  In Python3, this was changed
-# and sys.platform now returns 'linux' regardless of the kernel version.
-# See https://bugs.python.org/issue12326
-# sgsix.platform will mimick the python3 behavior to simplify code.
-platform = "linux" if sys.platform.startswith("linux") else sys.platform
+
+def normalize_platform(platform):
+    """
+    Normalize the return of sys.platform between Python 2 and 3.
+
+    On Python 2 on linux hosts, sys.platform was 'linux' appended with the
+    current kernel version that Python was built on.  In Python3, this was
+    changed and sys.platform now returns 'linux' regardless of the kernel version.
+    See https://bugs.python.org/issue12326
+    This function will normalize Python2 platform strings to the expected
+    Python 3 platform string.
+
+    :param str platform: The platform string to normalize
+
+    :returns: The normalized platform string.
+    :rtype: str
+    """
+    return "linux" if sys.platform.startswith("linux") else sys.platform
+
+
+# sgsix.platform will mimick the python3 sys.platform behavior to simplify code.
+platform = normalize_platform(sys.platform)

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -33,6 +33,7 @@
 
 from . import six
 import io
+import sys
 
 # For python 3, the `file` type no longer exists, and open() returns an
 # io.IOBase instance. We add file_types to allow comparison across python
@@ -55,3 +56,10 @@ if six.PY3:
 else:
     from .httplib2 import SSLHandshakeError
     ShotgunSSLError = SSLHandshakeError
+
+# On Python 2 on linux hosts, sys.platform was 'linux' appended with the
+# current kernel version that Python was built on.  In Python3, this was changed
+# and sys.platform now returns 'linux' regardless of the kernel version.
+# See https://bugs.python.org/issue12326
+# sgsix.platform will mimick the python3 behavior to simplify code.
+platform = "linux" if sys.platform.startswith("linux") else sys.platform

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -58,7 +58,7 @@ else:
     ShotgunSSLError = SSLHandshakeError
 
 
-def normalize_platform(platform):
+def normalize_platform(platform, python2=True):
     """
     Normalize the return of sys.platform between Python 2 and 3.
 
@@ -66,16 +66,22 @@ def normalize_platform(platform):
     current kernel version that Python was built on.  In Python3, this was
     changed and sys.platform now returns 'linux' regardless of the kernel version.
     See https://bugs.python.org/issue12326
-    This function will normalize Python2 platform strings to the expected
-    Python 3 platform string.
+    This function will normalize platform strings to always conform to Python2 or
+    Python3 behavior.
 
     :param str platform: The platform string to normalize
+    :param bool python2: The python version behavior to target.  If True, a
+        Python2-style platform string will be returned (i.e. 'linux2'), otherwise
+        the modern 'linux' platform string will be returned.
 
     :returns: The normalized platform string.
     :rtype: str
     """
-    return "linux" if sys.platform.startswith("linux") else sys.platform
+    if python2:
+        return "linux2" if platform.startswith("linux") else platform
+    return "linux" if platform.startswith("linux") else platform
 
 
-# sgsix.platform will mimick the python3 sys.platform behavior to simplify code.
+# sgsix.platform will mimick the python2 sys.platform behavior to ensure
+# compatibility with existing comparisons and dict keys.
 platform = normalize_platform(sys.platform)

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -33,7 +33,6 @@
 
 from . import six
 import io
-import re
 import sys
 
 # For python 3, the `file` type no longer exists, and open() returns an

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -33,6 +33,7 @@
 
 from . import six
 import io
+import re
 import sys
 
 # For python 3, the `file` type no longer exists, and open() returns an
@@ -56,6 +57,15 @@ if six.PY3:
 else:
     from .httplib2 import SSLHandshakeError
     ShotgunSSLError = SSLHandshakeError
+
+# In Python 3, regular expression metacharacters match unicode characters where in
+# Python 2 they hadn't.  To reproduce the previous behavior, Python 3 introduces a
+# new re.ASCII flag, which does not exist in Python 2.  Add a constant that contains
+# the value of re.ASCII in Python 3 and 0 (no flags) in Python 2.
+if six.PY2:
+    RE_ASCII = 0
+else:
+    RE_ASCII = re.ASCII
 
 
 def normalize_platform(platform, python2=True):

--- a/shotgun_api3/lib/sgsix.py
+++ b/shotgun_api3/lib/sgsix.py
@@ -58,15 +58,6 @@ else:
     from .httplib2 import SSLHandshakeError
     ShotgunSSLError = SSLHandshakeError
 
-# In Python 3, regular expression metacharacters match unicode characters where in
-# Python 2 they hadn't.  To reproduce the previous behavior, Python 3 introduces a
-# new re.ASCII flag, which does not exist in Python 2.  Add a constant that contains
-# the value of re.ASCII in Python 3 and 0 (no flags) in Python 2.
-if six.PY2:
-    RE_ASCII = 0
-else:
-    RE_ASCII = re.ASCII
-
 
 def normalize_platform(platform, python2=True):
     """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2776,15 +2776,17 @@ class TestLibImports(base.LiveTestBase):
 
     def test_import_httplib(self):
         """
-        Ensure that httplib2 is importable and objects are available as
-        expected.  This is important, because httplib2 imports switch between
+        Ensure that httplib2 is importable and objects are available
+
+        This is important, because httplib2 imports switch between
         the Python 2 and 3 compatible versions, and the module imports are
         proxied to allow this.
         """
         from shotgun_api3.lib import httplib2
         # Ensure that Http object is available.  This is a good indication that
         # the httplib2 module contents are importable.
-        self.assertIsInstance(httplib2.Http, object)
+        self.assertTrue(hasattr(httplib2, "Http"))
+        self.assertTrue(isinstance(httplib2.Http, object))
 
         # Ensure that the version of httplib2 compatible with the current Python
         # version was imported.
@@ -2801,9 +2803,9 @@ class TestLibImports(base.LiveTestBase):
         # import -- this is a good indication that external httplib2 imports
         # from shotgun_api3 will work as expected.
         from shotgun_api3.lib.httplib2 import socks
-        self.assertIsInstance(socks, types.ModuleType)
+        self.assertTrue(isinstance(socks, types.ModuleType))
         # Make sure that objects in socks are available as expected
-        self.assertIsInstance(socks.HTTPError, object)
+        self.assertTrue(hasattr(socks, "HTTPError"))
 
 
 def _has_unicode(data):


### PR DESCRIPTION
Update sgsix module to include additional functionality added during port of tk-core.

Update the httplib2 import procedure to ensure that members not exposed in `__all__` are still available as expected.