### PR TITLE
SG-16899 httplib2 relative import

### DIFF
--- a/shotgun_api3/lib/httplib2/README.md
+++ b/shotgun_api3/lib/httplib2/README.md
@@ -1,0 +1,5 @@
+Currently this library is pulled from a fork of httplib2 (https://github.com/shotgunsoftware/httplib2)
+
+The reason for the fork is to make a minor fix to the imports that was causing IronPython2.7 ImportErrors. 
+
+The fix has been submitted to httplib2 repo and already merged so this will likely not be necessary as soon as httplib2 is next released. (>v0.17.2) 

--- a/shotgun_api3/lib/httplib2/python2/__init__.py
+++ b/shotgun_api3/lib/httplib2/python2/__init__.py
@@ -122,7 +122,7 @@ if ssl is None:
     _ssl_wrap_socket = _ssl_wrap_socket_unsupported
 
 if sys.version_info >= (2, 3):
-    from iri2uri import iri2uri
+    from .iri2uri import iri2uri
 else:
 
     def iri2uri(uri):


### PR DESCRIPTION
In certain situations IronPython2.7 doesn't search the local directory on absolute imports. Fixing the module locally until the next httplib2 release which should include the fix. 