### PR TITLE
Add timeout support on upload operations

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3976,7 +3976,10 @@ class Shotgun(object):
             request.add_header("Content-Type", content_type)
             request.add_header("Content-Length", size)
             request.get_method = lambda: "PUT"
-            result = opener.open(request)
+            if self.config.timeout_secs is not None:
+                result = opener.open(request, timeout=self.config.timeout_secs)
+            else:
+                result = opener.open(request)
             etag = result.info()["Etag"]
         except urllib.error.HTTPError as e:
             if e.code == 500:
@@ -4069,7 +4072,10 @@ class Shotgun(object):
 
         # Perform the request
         try:
-            resp = opener.open(url, params)
+            if self.config.timeout_secs is not None:
+                resp = opener.open(url, params, timeout=self.config.timeout_secs)
+            else:
+                resp = opener.open(url, params)
             result = resp.read()
             # response headers are in str(resp.info()).splitlines()
         except urllib.error.HTTPError as e:


### PR DESCRIPTION
**Adds the support for timeout on upload request.**

According to this old post:
https://groups.google.com/a/shotgunsoftware.com/d/msg/shotgun-dev/P-YXTWs9mp0/tzXtkIALt1sJ

It was not added to shotgun API due to a backward compatibility necessity with python 2.4.
Since python 2.6 is now a requirement for the API to work it does not create an issue anymore and can be added.

It has became a priority due to the COVID situation, Shotgun creates a lot of timeouts when uploading thumbnails and playblasts.