### PR TITLE
Initial implementation of retries on 502 response.

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3332,8 +3332,13 @@ class Shotgun(object):
         backoff = 0.75 # Seconds to wait before retry, times the attempt number
 
         while attempt <= max_attempts:
-            http_status, resp_headers, body = self._make_call("POST", self.config.api_path,
-                                                            encoded_payload, req_headers)
+            http_status, resp_headers, body = self._make_call(
+                "POST",
+                self.config.api_path,
+                encoded_payload,
+                req_headers,
+            )
+
             LOG.debug("Completed rpc call to %s" % (method))
 
             try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -371,6 +371,13 @@ class TestShotgunClient(base.MockTestBase):
         expected = "rpc response with list result"
         self.assertEqual(d["results"], rv, expected)
 
+        # Test that we raise on a 502. This is ensuring the retries behavior
+        # in place specific to 502 responses still eventually ends up raising.
+        d = {"results": ["foo", "bar"]}
+        a = {"some": "args"}
+        self._mock_http(d, status=502)
+        self.assertRaises(self.sg._call_rpc("list", a))
+
     def test_transform_data(self):
         """Outbound data is transformed"""
         timestamp = time.time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -376,7 +376,7 @@ class TestShotgunClient(base.MockTestBase):
         d = {"results": ["foo", "bar"]}
         a = {"some": "args"}
         self._mock_http(d, status=(502, "bad gateway"))
-        self.assertRaises(self.sg._call_rpc("list", a))
+        self.assertRaises(api.ProtocolError, self.sg._call_rpc, "list", a)
 
     def test_transform_data(self):
         """Outbound data is transformed"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -375,7 +375,7 @@ class TestShotgunClient(base.MockTestBase):
         # in place specific to 502 responses still eventually ends up raising.
         d = {"results": ["foo", "bar"]}
         a = {"some": "args"}
-        self._mock_http(d, status=502)
+        self._mock_http(d, status=(502, "bad gateway"))
         self.assertRaises(self.sg._call_rpc("list", a))
 
     def test_transform_data(self):


### PR DESCRIPTION
Will retry 3 times with ascending backoff times for simple (ie: non-upload/download) API calls.