### PR TITLE
mimetypes.py: fix incompatibility with python3 due to old 'print' keyword and exception 'comma' syntax

### DIFF
--- a/shotgun_api3/lib/mimetypes.py
+++ b/shotgun_api3/lib/mimetypes.py
@@ -568,14 +568,14 @@ More than one type argument may be given.
 """
 
     def usage(code, msg=''):
-        print USAGE
-        if msg: print msg
+        print(USAGE)
+        if msg: print(msg)
         sys.exit(code)
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hle',
                                    ['help', 'lenient', 'extension'])
-    except getopt.error, msg:
+    except getopt.error as msg:
         usage(1, msg)
 
     strict = 1
@@ -590,9 +590,9 @@ More than one type argument may be given.
     for gtype in args:
         if extension:
             guess = guess_extension(gtype, strict)
-            if not guess: print "I don't know anything about type", gtype
-            else: print guess
+            if not guess: print("I don't know anything about type"), gtype
+            else: print(guess)
         else:
             guess, encoding = guess_type(gtype, strict)
-            if not guess: print "I don't know anything about type", gtype
-            else: print 'type:', guess, 'encoding:', encoding
+            if not guess: print("I don't know anything about type"), gtype
+            else: print('type:', guess, 'encoding:', encoding)


### PR DESCRIPTION
Changing print statements from the old py2 'print' keyword syntax into the newer 'print' function syntax, also changing one try-except exception catching from the old 'comma' syntax to the newer 'as' keyword syntax. Now this module can be imported in both python3 and python2 safely, prior to that it was not compatible with python3.

Note: the 'as' assignment within an exception catching is not compatible with python <= 2.5 but it is better to have this module compatible with python3 than with python <= 2.5 (https://peps.python.org/pep-3110/)