### PR TITLE
SG-21915 Mockgun returns dictionary list instead of individual item

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -395,7 +395,7 @@ class Shotgun(object):
         row = self._db[entity_type][entity_id]
         self._update_row(entity_type, row, data)
 
-        return [dict((field, item) for field, item in row.items() if field in data or field in ("type", "id"))]
+        return dict((field, item) for field, item in row.items() if field in data or field in ("type", "id"))
 
     def delete(self, entity_type, entity_id):
         self._validate_entity_type(entity_type)

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -1028,10 +1028,13 @@ class Shotgun(object):
         params[paging_info_param] = True
         records = []
 
+        # limit = 6000
+        # params["entitites x ..."] = 5000
+
         if self.server_caps.ensure_paging_info_without_counts_support():
             has_next_page = True
             while has_next_page:
-                result = self._call_rpc("read", params)
+                result = self._call_rpc("read", params)  # 5000,has_next_page = True
                 records.extend(result.get("entities"))
 
                 if limit and len(records) >= limit:


### PR DESCRIPTION
This is a draft PR testing the effects of returning a dict instead of a list of dict in update method of mockgun (python-api mock class).