### PR TITLE
SG-29417 [Python API Documentation] Update Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The latest version can always be found at http://github.com/shotgunsoftware/pyth
 
 ## Minimum Requirements
 
-* ShotGrid server v2.4.12+.
 * Python v3.7
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The latest version can always be found at http://github.com/shotgunsoftware/pyth
 ## Minimum Requirements
 
 * ShotGrid server v2.4.12+.
-* Python v2.7 or v3.7
+* Python v3.7
 
 ## Documentation
 Tutorials and detailed documentation about the Python API are available at http://developer.shotgridsoftware.com/python-api).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,9 +6,6 @@ Installation
 Minimum Requirements
 ********************
 
-- ShotGrid server v5.4.14 or higher for API v3.0.16+.
-- ShotGrid server v2.4.12 or higher for API v3.0.8.
-- ShotGrid server v1.8 or higher for API v3.0.7.
 - Python 3.7
 
 .. note::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Minimum Requirements
 - ShotGrid server v5.4.14 or higher for API v3.0.16+.
 - ShotGrid server v2.4.12 or higher for API v3.0.8.
 - ShotGrid server v1.8 or higher for API v3.0.7.
-- Python 2.7 or Python 3.7
+- Python 3.7
 
 .. note::
     Some features of the API are only supported by more recent versions of the ShotGrid server.


### PR DESCRIPTION
Remove python 2.7 from readme and docs sections "Minimum requirements"