### PR TITLE
SG-32806 Enable support for Python 3.10 in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2020-blue.svg)](http://www.vfxplatform.com/)
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023-blue.svg)](http://www.vfxplatform.com/)
+[![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
 [![Reference Documentation](http://img.shields.io/badge/doc-reference-blue.svg)](http://developer.shotgridsoftware.com/python-api)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Python%20API/_apis/build/status/shotgunsoftware.python-api?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Python%20API/_build/latest?definitionId=108&branchName=master)
 [![Coverage Status](https://coveralls.io/repos/github/shotgunsoftware/python-api/badge.svg?branch=master)](https://coveralls.io/github/shotgunsoftware/python-api?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023-blue.svg)](http://www.vfxplatform.com/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023%202022%202021%202020-blue.svg)](http://www.vfxplatform.com/)
 [![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
 [![Reference Documentation](http://img.shields.io/badge/doc-reference-blue.svg)](http://developer.shotgridsoftware.com/python-api)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Python%20API/_apis/build/status/shotgunsoftware.python-api?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Python%20API/_build/latest?definitionId=108&branchName=master)

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -50,8 +50,6 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
-      Python311:
-        python.version: '3.11'
       # Note for Python 3.11. This will raise hundres of warnings on a third party module
       # pytest_nunit/nunit.py
       # DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -43,11 +43,16 @@ jobs:
   # matrix.
   strategy:
     matrix:
-      # We support these two versions of Python.
+      # We support these versions of Python.
       Python37:
         python.version: '3.7'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
+      Python311:
+        python.version: '3.11'
+    maxParallel: 4
 
   # These are the steps that will be executed inside each job.
   steps:

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -52,6 +52,11 @@ jobs:
         python.version: '3.10'
       Python311:
         python.version: '3.11'
+      # Note for Python 3.11. This will raise hundres of warnings on a third party module
+      # pytest_nunit/nunit.py
+      # DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead
+      # This is the current behavior on the latest 1.0.3 version of this module.
+
     maxParallel: 4
 
   # These are the steps that will be executed inside each job.

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
       # DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead
       # This is the current behavior on the latest 1.0.3 version of this module.
 
-    maxParallel: 4
+    maxParallel: 3
 
   # These are the steps that will be executed inside each job.
   steps:


### PR DESCRIPTION
We need to ~~rebase #305 and~~ complete SG-32847 before testing this again.

- [x] ssl.PROTOCOL_TLS is deprecated
    - Upgrades httplib2 module
- [x] ssl.wrap_socket() is [deprecated](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket), use SSLContext.wrap_socket()
    - Upgraded syntax
- [ ] module 'sre_constants' is deprecated (only on Python 3.11)
    - pyparsing should be upgraded. We can work on this later since this needs more testing.