### PR TITLE
SG-31927 Flaky Test In python-api Test Work schedule

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -842,7 +842,6 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertEqual(expected, resp)
         resp = self.sg.work_schedule_read(start_date, end_date, project, user)
         work_schedule['2012-01-04'] = {"reason": "USER_EXCEPTION", "working": False, "description": "Artist Holiday"}
-        # FIXME: There seems to be a regresion on the Shotgun server that needs to be fixed. Disabling the test
         self.assertEqual(work_schedule, resp)
 
     # For now disable tests that are erroneously failling on some sites to

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -785,12 +785,13 @@ class TestShotgunApi(base.LiveTestBase):
         end_date_obj = datetime.datetime(2012, 1, 7)
 
         project = self.project
-        # We're going to be comparing this value with the value returned from the server, so extract only the type
-        # and id
+        # We're going to be comparing this value with the value returned from the server, so extract only the type, id
+        # and name
         user = {"type": self.human_user["type"], "id": self.human_user["id"], "name": self.human_user["name"]}
 
         work_schedule = self.sg.work_schedule_read(start_date, end_date, project, user)
-
+        # Test that the work_schedule_read api method is called with the 'start_date' and 'end_date' arguments
+        # in the 'YYYY-MM-DD' string format.
         self.assertRaises(shotgun_api3.ShotgunError, self.sg.work_schedule_read,
                           start_date_obj, end_date_obj, project, user)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -794,8 +794,6 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertRaises(shotgun_api3.ShotgunError, self.sg.work_schedule_read,
                           start_date_obj, end_date_obj, project, user)
 
-        resp = self.sg.work_schedule_read(start_date, end_date, project, user)
-        self.assertEqual(work_schedule, resp)
 
         resp = self.sg.work_schedule_update('2012-01-02', False, 'Studio Holiday')
         expected = {


### PR DESCRIPTION
Removing a flaky assertion that compares two calls to work_schedule_read() with the same parameters, as it serves no clear purpose and occasionally fails in the CI. Running this same test by making real calls to the python-api correctly returns the `WorkDayRules` defined between the given `start_date `and `end_date`.