### PR TITLE
Travis badge image is no working anymore

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,6 @@ ShotGrid Python API3
 Release |version|. (:ref:`Installation <installation>`)
 
 .. image:: https://img.shields.io/badge/shotgun-api-blue.svg
-.. image:: https://secure.travis-ci.org/shotgunsoftware/python-api.svg?branch=master
 
 
 


### PR DESCRIPTION
 We don't even use Travis anyway


![image](https://github.com/shotgunsoftware/python-api/assets/16244608/40228d10-7e30-4023-9311-82cd543010f1)

