### PR TITLE
SG-34199 #comment typing annotation breaks Python 2 compatibility

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -3273,7 +3273,8 @@ class Shotgun(object):
 
         return self._call_rpc("user_subscriptions_read", None)
 
-    def user_subscriptions_create(self, users: list):
+    def user_subscriptions_create(self, users):
+        # type: (list[dict[str, Union[str, list[str], None]) -> bool
         """
         Assign subscriptions to users.
 


### PR DESCRIPTION
We pull `shotgun_api3` directly for deployment here at TTF. We have some old shows still using Maya2019 (and thereby Python 2). This addition of hinting annotations breaks import of your packages. If it's intentional, and you are dropping Py2 support, then disregard this PR. In that case, we'll have to lock our release for our Py2 deployments (while we have them).