### PR TITLE
SG-34359 Add field type `entity_type` to mockgun as simple str

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -495,6 +495,7 @@ class Shotgun(object):
                                    "checkbox": bool,
                                    "percent": int,
                                    "text": six.string_types,
+                                   "entity_type": six.string_types,
                                    "serializable": dict,
                                    "date": datetime.date,
                                    "date_time": datetime.datetime,


### PR DESCRIPTION
For testing purposes, it can be helpful to support `entity_type` field types, even if there's no validation that it's an existing Entity from the schema.