### PR TITLE
add set_session_uuid to mockgun

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -226,6 +226,10 @@ class Shotgun(object):
     def get_session_token(self):
         return "bogus_session_token"
 
+    def set_session_uuid(self, session_uuid):
+        """Set the browser session_uuid. This has no real effect in mockgun."""
+        self.config.session_uuid = session_uuid
+
     def schema_read(self):
         return self._schema
 


### PR DESCRIPTION
Adds set_session_uuid to mockgun.  This has no real effect, but allows code to be tested that calls the [real function](https://github.com/shotgunsoftware/python-api/blob/1666c39956207a9cde377b319c9df45bd9745eb2/shotgun_api3/shotgun.py#L2191).