### PR TITLE
SG-35018 Remove Ticket entity reference and prepare this to run in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tests/config
 .travis-solo
 htmlcov
 test-output.xml
+coverage.xml
 
 # setup related
 build

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -129,7 +129,6 @@ jobs:
       SG_VERSION_CODE: CI-$(python_api_human_login)-${{parameters.name}}-$(python.version)
       SG_SHOT_CODE: CI-$(python_api_human_login)-${{parameters.name}}-$(python.version)
       SG_TASK_CONTENT: CI-$(python_api_human_login)-${{parameters.name}}-$(python.version)
-      SG_TICKET_TILE: CI-$(python_api_human_login)-${{parameters.name}}-$(python.version)
       SG_PLAYLIST_CODE: CI-$(python_api_human_login)-${{parameters.name}}-$(python.version)
 
   # Upload the code coverage result to codecov.io.

--- a/tests/base.py
+++ b/tests/base.py
@@ -397,7 +397,7 @@ class SgTestConfig(object):
             'api_key', 'asset_code', 'http_proxy', 'human_login', 'human_name',
             'human_password', 'mock', 'project_name', 'script_name',
             'server_url', 'session_uuid', 'shot_code', 'task_content',
-            'version_code', 'playlist_code', 'ticket_title'
+            'version_code', 'playlist_code'
         ]
 
     def read_config(self, config_path):

--- a/tests/base.py
+++ b/tests/base.py
@@ -260,11 +260,18 @@ class LiveTestBase(TestBase):
         # When running the tests from a pull request from a client, the Shotgun
         # site URL won't be set, so do not attempt to connect to Shotgun.
         if cls.config.server_url:
-            sg = api.Shotgun(
-                cls.config.server_url,
-                cls.config.script_name,
-                cls.config.api_key
-            )
+            if cls.config.jenkins:
+                sg = api.Shotgun(
+                    cls.config.server_url,
+                    login=cls.config.human_login,
+                    password=cls.config.human_password
+                )
+            else:
+                sg = api.Shotgun(
+                    cls.config.server_url,
+                    cls.config.script_name,
+                    cls.config.api_key
+                )
             cls.sg_version = tuple(sg.info()['version'][:3])
             cls._setup_db(cls.config, sg)
 
@@ -396,7 +403,7 @@ class SgTestConfig(object):
             'api_key', 'asset_code', 'http_proxy', 'human_login', 'human_name',
             'human_password', 'mock', 'project_name', 'script_name',
             'server_url', 'session_uuid', 'shot_code', 'task_content',
-            'version_code', 'playlist_code'
+            'version_code', 'playlist_code', 'jenkins'
         ]
 
     def read_config(self, config_path):

--- a/tests/base.py
+++ b/tests/base.py
@@ -227,9 +227,6 @@ class MockTestBase(TestBase):
         self.version = {'id': 5,
                         'code': self.config.version_code,
                         'type': 'Version'}
-        self.ticket = {'id': 6,
-                       'title': self.config.ticket_title,
-                       'type': 'Ticket'}
         self.playlist = {'id': 7,
                          'code': self.config.playlist_code,
                          'type': 'Playlist'}
@@ -329,12 +326,6 @@ class LiveTestBase(TestBase):
                 'task_assignees': [cls.human_user],
                 'sg_status_list': 'ip'}
         cls.task = _find_or_create_entity(sg, 'Task', data, keys)
-
-        data = {'project': cls.project,
-                'title': cls.config.ticket_title,
-                'sg_priority': '3'}
-        keys = ['title', 'project', 'sg_priority']
-        cls.ticket = _find_or_create_entity(sg, 'Ticket', data, keys)
 
         keys = ['code']
         data = {'code': 'api wrapper test storage',

--- a/tests/base.py
+++ b/tests/base.py
@@ -39,7 +39,6 @@ class TestBase(unittest.TestCase):
     note = None
     playlist = None
     task = None
-    ticket = None
     human_password = None
     server_url = None
     server_address = None

--- a/tests/example_config
+++ b/tests/example_config
@@ -34,5 +34,4 @@ asset_code     : Sg unittest asset
 version_code   : Sg unittest version
 shot_code      : Sg unittest shot
 task_content   : Sg unittest task
-ticket_title   : Sg unittest ticket
 playlist_code  : Sg unittest playlist

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1521,6 +1521,36 @@ class TestFind(base.LiveTestBase):
         result = self._id_in_result('Version', filters, self.version['id'])
         self.assertFalse(result)
 
+    def test_in_relation_comma_list(self):
+        """
+        Test that 'in' relation using commas (old format) works with list fields.
+        """
+        filters = [['frame_count', 'in', self.version['frame_count'], 33],
+                   ['project', 'is', self.project]]
+
+        result = self._id_in_result('Version', filters, self.version['id'])
+        self.assertTrue(result)
+
+    def test_in_relation_list_list(self):
+        """
+        Test that 'in' relation using list (new format) works with list fields.
+        """
+        filters = [['frame_count', 'in', [self.version['frame_count'], 33]],
+                   ['project', 'is', self.project]]
+
+        result = self._id_in_result('Version', filters, self.version['id'])
+        self.assertTrue(result)
+
+    def test_not_in_relation_list(self):
+        """
+        Test that 'not_in' relation using commas (old format) works with list fields.
+        """
+        filters = [['frame_count', 'not_in', [self.version['frame_count'], 33]],
+                   ['project', 'is', self.project]]
+
+        result = self._id_in_result('Version', filters, self.version['id'])
+        self.assertFalse(result)
+
     def test_in_relation_comma_multi_entity(self):
         """
         Test that 'in' relation using commas (old format) works with multi_entity fields.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,8 +171,8 @@ class TestShotgunApi(base.LiveTestBase):
             os.path.join(this_dir, "sg_logo.jpg")))
         size = os.stat(path).st_size
 
-        attach_id = self.sg.upload("Ticket",
-                                   self.ticket['id'], path, 'attachments',
+        attach_id = self.sg.upload("Version",
+                                   self.version['id'], path, 'attachments',
                                    tag_list="monkeys, everywhere, send, help")
 
         # test download with attachment_id
@@ -201,12 +201,12 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertEqual(orig_file, attach_file)
 
         # test download with attachment hash
-        ticket = self.sg.find_one('Ticket', [['id', 'is', self.ticket['id']]],
+        version = self.sg.find_one('Version', [['id', 'is', self.version['id']]],
                                   ['attachments'])
 
         # Look for the attachment we just uploaded, the attachments are not returned from latest
         # to earliest.
-        attachment = [x for x in ticket["attachments"] if x["id"] == attach_id]
+        attachment = [x for x in version["attachments"] if x["id"] == attach_id]
         self.assertEqual(len(attachment), 1)
 
         attachment = attachment[0]
@@ -254,8 +254,8 @@ class TestShotgunApi(base.LiveTestBase):
         # only checking that the non-ascii string encoding doesn't trip
         # us up the way it used to.
         self.sg.upload(
-            "Ticket",
-            self.ticket['id'],
+            "Version",
+            self.version['id'],
             u_path,
             'attachments',
             tag_list="monkeys, everywhere, send, help"
@@ -266,8 +266,8 @@ class TestShotgunApi(base.LiveTestBase):
         # primarily a concern on Windows, as it doesn't handle that
         # situation as well as OS X and Linux.
         self.sg.upload(
-            "Ticket",
-            self.ticket['id'],
+            "Version",
+            self.version['id'],
             u_path.encode("utf-8"),
             'attachments',
             tag_list="monkeys, everywhere, send, help"
@@ -290,8 +290,8 @@ class TestShotgunApi(base.LiveTestBase):
             self.assertRaises(
                 shotgun_api3.ShotgunError,
                 self.sg.upload,
-                "Ticket",
-                self.ticket['id'],
+                "Version",
+                self.version['id'],
                 file_path_u.encode("shift-jis"),
                 'attachments',
                 tag_list="monkeys, everywhere, send, help"
@@ -299,8 +299,8 @@ class TestShotgunApi(base.LiveTestBase):
 
             # But it should work in all cases if a unicode string is used.
             self.sg.upload(
-                "Ticket",
-                self.ticket['id'],
+                "Version",
+                self.version['id'],
                 file_path_u,
                 'attachments',
                 tag_list="monkeys, everywhere, send, help"
@@ -330,8 +330,8 @@ class TestShotgunApi(base.LiveTestBase):
             )
         )
         upload_id = self.sg.upload(
-            "Ticket",
-            self.ticket['id'],
+            "Version",
+            self.version['id'],
             u_path,
             'attachments',
             tag_list="monkeys, everywhere, send, help"
@@ -345,8 +345,8 @@ class TestShotgunApi(base.LiveTestBase):
         )
 
         upload_id = self.sg.upload(
-            "Ticket",
-            self.ticket['id'],
+            "Version",
+            self.version['id'],
             u_path,
             'filmstrip_image',
             tag_list="monkeys, everywhere, send, help",
@@ -365,8 +365,8 @@ class TestShotgunApi(base.LiveTestBase):
         self.assertRaises(
             shotgun_api3.ShotgunError,
             self.sg.upload,
-            "Ticket",
-            self.ticket['id'],
+            "Version",
+            self.version['id'],
             u_path,
             'attachments',
             tag_list="monkeys, everywhere, send, help"
@@ -1519,36 +1519,6 @@ class TestFind(base.LiveTestBase):
                    ['project', 'is', self.project]]
 
         result = self._id_in_result('Version', filters, self.version['id'])
-        self.assertFalse(result)
-
-    def test_in_relation_comma_list(self):
-        """
-        Test that 'in' relation using commas (old format) works with list fields.
-        """
-        filters = [['sg_priority', 'in', self.ticket['sg_priority'], '1'],
-                   ['project', 'is', self.project]]
-
-        result = self._id_in_result('Ticket', filters, self.ticket['id'])
-        self.assertTrue(result)
-
-    def test_in_relation_list_list(self):
-        """
-        Test that 'in' relation using list (new format) works with list fields.
-        """
-        filters = [['sg_priority', 'in', [self.ticket['sg_priority'], '1']],
-                   ['project', 'is', self.project]]
-
-        result = self._id_in_result('Ticket', filters, self.ticket['id'])
-        self.assertTrue(result)
-
-    def test_not_in_relation_list(self):
-        """
-        Test that 'not_in' relation using commas (old format) works with list fields.
-        """
-        filters = [['sg_priority', 'not_in', [self.ticket['sg_priority'], '1']],
-                   ['project', 'is', self.project]]
-
-        result = self._id_in_result('Ticket', filters, self.ticket['id'])
         self.assertFalse(result)
 
     def test_in_relation_comma_multi_entity(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -172,7 +172,7 @@ class TestShotgunApi(base.LiveTestBase):
         size = os.stat(path).st_size
 
         attach_id = self.sg.upload("Version",
-                                   self.version['id'], path, 'attachments',
+                                   self.version['id'], path, 'sg_uploaded_movie',
                                    tag_list="monkeys, everywhere, send, help")
 
         # test download with attachment_id
@@ -202,11 +202,11 @@ class TestShotgunApi(base.LiveTestBase):
 
         # test download with attachment hash
         version = self.sg.find_one('Version', [['id', 'is', self.version['id']]],
-                                  ['attachments'])
+                                  ['sg_uploaded_movie'])
 
         # Look for the attachment we just uploaded, the attachments are not returned from latest
         # to earliest.
-        attachment = [x for x in version["attachments"] if x["id"] == attach_id]
+        attachment = [v for k, v in version["sg_uploaded_movie"].items() if (k, v) == ("id", attach_id)]
         self.assertEqual(len(attachment), 1)
 
         attachment = attachment[0]
@@ -257,7 +257,7 @@ class TestShotgunApi(base.LiveTestBase):
             "Version",
             self.version['id'],
             u_path,
-            'attachments',
+            'sg_uploaded_movie',
             tag_list="monkeys, everywhere, send, help"
         )
 
@@ -269,7 +269,7 @@ class TestShotgunApi(base.LiveTestBase):
             "Version",
             self.version['id'],
             u_path.encode("utf-8"),
-            'attachments',
+            'sg_uploaded_movie',
             tag_list="monkeys, everywhere, send, help"
         )
         if six.PY2:
@@ -293,7 +293,7 @@ class TestShotgunApi(base.LiveTestBase):
                 "Version",
                 self.version['id'],
                 file_path_u.encode("shift-jis"),
-                'attachments',
+                'sg_uploaded_movie',
                 tag_list="monkeys, everywhere, send, help"
             )
 
@@ -302,7 +302,7 @@ class TestShotgunApi(base.LiveTestBase):
                 "Version",
                 self.version['id'],
                 file_path_u,
-                'attachments',
+                'sg_uploaded_movie',
                 tag_list="monkeys, everywhere, send, help"
             )
 


### PR DESCRIPTION
Ticket entity is disabled by default on ShotGrid (it seems so).

![image](https://github.com/shotgunsoftware/python-api/assets/123113322/6b886917-70a8-43d8-8a53-db7e26c62695)

I'm making unit tests dependant-free on this entity. It seems they were enabled when these tests were implemented, but now this is making it harder to test locally with fresh SG sites.