### PR TITLE
SG-37203 [Mockgun] ignore duplicate entities when multi_entity_update_mode is add

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -831,7 +831,10 @@ class Shotgun(object):
                 update_mode = multi_entity_update_modes.get(field, "set") if multi_entity_update_modes else "set"
 
                 if update_mode == "add":
-                    row[field] += [{"type": item["type"], "id": item["id"]} for item in data[field]]
+                    for item in data[field]:
+                        new_item = {"type": item["type"], "id": item["id"]}
+                        if new_item not in row[field]:
+                            row[field].append(new_item)
                 elif update_mode == "remove":
                     row[field] = [
                         item

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -311,8 +311,9 @@ class TestMultiEntityFieldUpdate(unittest.TestCase):
         """
         Ensures that "add" multi_entity_update_mode works.
         """
+        # _version2 already exists on the playlist and should not be duplicated
         self._mockgun.update(
-            "Playlist", self._add_playlist["id"], {"versions": [self._version3]},
+            "Playlist", self._add_playlist["id"], {"versions": [self._version2, self._version3]},
             multi_entity_update_modes={"versions": "add"}
         )
 


### PR DESCRIPTION
fixes oversight in https://github.com/shotgunsoftware/python-api/pull/330 which allowed duplicate entities to be added when `multi_entity_update_mode` was `add`.

This fix emulates the server behavior which ignores duplicates when `add`ing to `multi-entity` fields.