### PR TITLE
SG-37544 Include the "in" and "not_in" operators for payload optimization

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4482,16 +4482,11 @@ def _translate_filters_simple(sg_filter):
     if (
         SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION
         and condition["path"] != "id"
-        and condition["relation"] in ["is", "is_not"]
+        and condition["relation"] in ["is", "is_not", "in", "not_in"]
         and isinstance(values[0], dict)
     ):
         try:
-            values = [
-                {
-                    "type": values[0]["type"],
-                    "id": values[0]["id"],
-                }
-            ]
+            values = [{"type": v["type"], "id": v["id"]} for v in values]
         except KeyError:
             pass
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -12,6 +12,7 @@
 
 import os
 import unittest
+from unittest import mock
 from .mock import patch
 import shotgun_api3 as api
 from shotgun_api3.shotgun import _is_mimetypes_broken
@@ -434,6 +435,7 @@ class TestFilters(unittest.TestCase):
         result = api.shotgun._translate_filters(filters, "all")
         self.assertEqual(result, expected)
 
+    @mock.patch.dict(os.environ, {"SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION": "1"})
     def test_related_object_entity_optimization_is(self):
         filters = [
             [
@@ -457,11 +459,11 @@ class TestFilters(unittest.TestCase):
                 }
             ],
         }
-        os.environ["SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION"] = "1"
         api.Shotgun("http://server_path", "script_name", "api_key", connect=False)
         result = api.shotgun._translate_filters(filters, "all")
         self.assertEqual(result, expected)
 
+    @mock.patch.dict(os.environ, {"SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION": "1"})
     def test_related_object_entity_optimization_in(self):
         filters = [
             [
@@ -492,7 +494,6 @@ class TestFilters(unittest.TestCase):
                 }
             ],
         }
-        os.environ["SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION"] = "1"
         api.Shotgun("http://server_path", "script_name", "api_key", connect=False)
         result = api.shotgun._translate_filters(filters, "all")
         self.assertEqual(result, expected)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -434,7 +434,7 @@ class TestFilters(unittest.TestCase):
         result = api.shotgun._translate_filters(filters, "all")
         self.assertEqual(result, expected)
 
-    def test_related_object_entity_optimization(self):
+    def test_related_object_entity_optimization_is(self):
         filters = [
             [
                 "project",
@@ -451,6 +451,41 @@ class TestFilters(unittest.TestCase):
                     "values": [
                         {
                             "id": 999,
+                            "type": "Anything",
+                        }
+                    ],
+                }
+            ],
+        }
+        os.environ["SHOTGUN_API_ENABLE_ENTITY_OPTIMIZATION"] = "1"
+        api.Shotgun("http://server_path", "script_name", "api_key", connect=False)
+        result = api.shotgun._translate_filters(filters, "all")
+        self.assertEqual(result, expected)
+
+    def test_related_object_entity_optimization_in(self):
+        filters = [
+            [
+                "project",
+                "in",
+                [
+                    {"foo1": "foo1", "bar1": "bar1", "id": 999, "baz1": "baz1", "type": "Anything"},
+                    {"foo2": "foo2", "bar2": "bar2", "id": 998, "baz2": "baz2", "type": "Anything"}
+                ],
+            ],
+        ]
+        expected = {
+            "logical_operator": "and",
+            "conditions": [
+                {
+                    "path": "project",
+                    "relation": "in",
+                    "values": [
+                        {
+                            "id": 999,
+                            "type": "Anything",
+                        },
+                        {
+                            "id": 998,
                             "type": "Anything",
                         }
                     ],


### PR DESCRIPTION
## Summary

This is a follow up work from #360 in this case including support for `in` and `not_in` [operators](https://developers.shotgridsoftware.com/python-api/reference.html#operators-and-arguments) for lists of entities.

## Affected methods
- find
- summarize
- text_search (API query_display_name_cache)

## Detailed Description
The change should transform calls like:

```python
sg.find("Asset",
        [[
            "project", "in",
            [
                {
                    "created_at": datetime.datetime(2015, 12, 16, 11, 2, 10, tzinfo),
                    "id": 72,
                    "name": "Demo: Game",
                    "type": "Project",
                    # ...
                },
                {
                    "created_at": datetime.datetime(2015, 12, 16, 11, 2, 10, tzinfo),
                    "id": 73,
                    "name": "Demo: Game 2",
                    "type": "Project",
                    # ...
                }
            ]
        ]]
)

```
as if the following had been called:
```python
sg.find('Asset', [['project', 'in', [{'id': 72, 'type': 'Project'}, {'id': 73, 'type': 'Project'}]]]) 
```