### PR TITLE
SG-37203 Support for None in mockgun when using order

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -293,6 +293,27 @@ class Shotgun(object):
         # handle the ordering of the recordset
         if order:
             # order: [{"field_name": "code", "direction": "asc"}, ... ]
+
+            def sort_none(k, order_field):
+                """
+                Handle sorting of None consistently.
+
+                Note: Doesn't handle [checkbox, serializable, url].
+                """
+                field_type = self._get_field_type(k["type"], order_field)
+                value = k[order_field]
+                if value is not None:
+                    return value
+                elif field_type in ("number", "percent", "duration"):
+                    return 0
+                elif field_type == "float":
+                    return 0.0
+                elif field_type in ("text", "entity_type", "date", "list", "status_list"):
+                    return ""
+                elif field_type == "date_time":
+                    return datetime.datetime(datetime.MINYEAR, 1, 1)
+                return None
+
             for order_entry in order:
                 if "field_name" not in order_entry:
                     raise ValueError("Order clauses must be list of dicts with keys 'field_name' and 'direction'!")
@@ -305,7 +326,11 @@ class Shotgun(object):
                 else:
                     raise ValueError("Unknown ordering direction")
 
-                results = sorted(results, key=lambda k: k[order_field], reverse=desc_order)
+                results = sorted(
+                    results,
+                    key=lambda k: sort_none(k, order_field),
+                    reverse=desc_order,
+                )
 
         if fields is None:
             fields = set(["type", "id"])


### PR DESCRIPTION
When using mockgun if you try to use order and any of your results contain `None` in the ordered fields it will raise a error like this.

`_mockgun.find("Shot", [], ["code"], order=[{"field_name": "description", "direction": "asc"}])`

```py
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\unittest\case.py", line 59, in testPartExecutor
    yield
  File "C:\Program Files\Python39\lib\unittest\case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "C:\Program Files\Python39\lib\unittest\case.py", line 550, in _callTestMethod
    method()
  File "C:\blur\dev\shotgun_api3\tests\test_mockgun.py", line 476, in test_ordered_filter_operator
    shots = self._mockgun.find(
  File "C:\blur\dev\shotgun_api3\shotgun_api3\lib\mockgun\mockgun.py", line 308, in find
    results = sorted(results, key=lambda k: k[order_field], reverse=desc_order)
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

This pull request converts most of the data types to a empty value for the data type. I wasn't sure what to use for the bool and dict datatypes so it currently doesn't handle those.