### PR TITLE
SG-35712 Prevent flaky disconnection when uploading thumbnails on publish

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4293,7 +4293,7 @@ class Shotgun(object):
             raise ShotgunError("Max attemps limit reached.")
 
 
-class CACertsHTTPSConnection(http_client.HTTPConnection):
+class CACertsHTTPSConnection(http_client.HTTPSConnection):
     """"
     This class allows to create an HTTPS connection that uses the custom certificates
     passed in.
@@ -4309,11 +4309,11 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
         """
         # Pop that argument,
         self.__ca_certs = kwargs.pop("ca_certs")
-        http_client.HTTPConnection.__init__(self, *args, **kwargs)
+        super().__init__(self, *args, **kwargs)
 
     def connect(self):
         "Connect to a host on a given (SSL) port."
-        http_client.HTTPConnection.connect(self)
+        super().connect(self)
         # Now that the regular HTTP socket has been created, wrap it with our SSL certs.
         if six.PY38:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -4330,13 +4330,13 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
             )
 
 
-class CACertsHTTPSHandler(urllib.request.HTTPSHandler):
+class CACertsHTTPSHandler(urllib.request.HTTPHandler):
     """
     Handler that ensures https connections are created with the custom CA certs.
     """
 
     def __init__(self, cacerts):
-        urllib.request.HTTPSHandler.__init__(self)
+        super().__init__(self)
         self.__ca_certs = cacerts
 
     def https_open(self, req):

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4151,16 +4151,16 @@ class Shotgun(object):
         :returns: upload url.
         :rtype: str
         """
-        opener = self._build_opener(urllib.request.HTTPHandler)
-
-        request = urllib.request.Request(storage_url, data=data)
-        request.add_header("Content-Type", content_type)
-        request.add_header("Content-Length", size)
-        request.get_method = lambda: "PUT"
 
         attempt = 1
         while attempt <= self.MAX_ATTEMPTS:
             try:
+                opener = self._build_opener(urllib.request.HTTPHandler)
+
+                request = urllib.request.Request(storage_url, data=data)
+                request.add_header("Content-Type", content_type)
+                request.add_header("Content-Length", size)
+                request.get_method = lambda: "PUT"
                 result = self._make_upload_request(request, opener)
 
                 LOG.debug("Completed request to %s" % request.get_method())
@@ -4267,12 +4267,12 @@ class Shotgun(object):
 
         params.update(self._auth_params())
 
-        opener = self._build_opener(FormPostHandler)
 
         attempt = 1
         while attempt <= self.MAX_ATTEMPTS:
             # Perform the request
             try:
+                opener = self._build_opener(FormPostHandler)
                 resp = opener.open(url, params)
                 result = resp.read()
                 # response headers are in str(resp.info()).splitlines()
@@ -4321,7 +4321,7 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
             context.check_hostname = False
             if self.__ca_certs:
                 context.load_verify_locations(self.__ca_certs)
-            self.sock = context.wrap_socket(self.sock)
+            self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
         else:
             self.sock = ssl.wrap_socket(
                 self.sock,

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4321,7 +4321,7 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
             context.check_hostname = False
             if self.__ca_certs:
                 context.load_verify_locations(self.__ca_certs)
-            self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
+            self.sock = context.wrap_socket(self.sock)
         else:
             self.sock = ssl.wrap_socket(
                 self.sock,

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4293,7 +4293,7 @@ class Shotgun(object):
             raise ShotgunError("Max attemps limit reached.")
 
 
-class CACertsHTTPSConnection(http_client.HTTPSConnection):
+class CACertsHTTPSConnection(http_client.HTTPConnection):
     """"
     This class allows to create an HTTPS connection that uses the custom certificates
     passed in.


### PR DESCRIPTION
There's a flaky disconnection when the publisher uploads the thumbnail. The most common errors are:

- Connection closed by peer
- URLopen error EOF occurred in violation of protocol ssl.c:1006

They seem to be related to TLS handshakes. While testing on local machines we consistently reproduced this with the following change: Move the connection opener to the retry block and change `CACertsHTTPSHandler` parent class.