### PR TITLE
Remove Python 3.7 from CI

### DIFF
--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -44,8 +44,6 @@ jobs:
   strategy:
     matrix:
       # We support these versions of Python.
-      Python37:
-        python.version: '3.7'
       Python39:
         python.version: '3.9'
       Python310:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1004,6 +1004,7 @@ class TestShotgunApi(base.LiveTestBase):
         resp = self.sg.preferences_read()
 
         expected = {
+            "creative_review_settings": "",
             "date_component_order": "month_day",
             "duration_units": "days",
             "format_currency_fields_decimal_options": "$1,000.99",


### PR DESCRIPTION
1️⃣  We're starting to get these errors on Azure Pipelines:

```
Starting: UsePythonVersion
==============================================================================
Task         : Use Python version
Description  : Use the specified version of Python from the tool cache, optionally adding it to the PATH
Version      : 0.248.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/use-python-version
==============================================================================
##[warning]You should provide GitHub token if you want to download a python release. Otherwise you may hit the GitHub anonymous download limit.
##[error]Failed to download Python from the Github Actions python registry (https://github.com/actions/python-versions). Error: Error: Could not find Python matching spec 3.7 (x64) in the python-versions registry. Beware that only systems listed in the Github Actions python versions manifest (https://github.com/actions/python-versions/blob/main/versions-manifest.json) are fit for downloading python on-flight. Also, proxy is not supported.
##[error]Version spec 3.7 for architecture x64 did not match any version in Agent.ToolsDirectory.
Versions in /opt/hostedtoolcache:

3.10.16 (x64)
3.11.11 (x64)
3.12.9 (x64)
3.13.2 (x64)
3.9.21 (x64)
If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of Python at https://aka.ms/hosted-agent-software.
If this is a self-hosted agent, see how to configure side-by-side Python versions at https://go.microsoft.com/fwlink/?linkid=871498.
Finishing: UsePythonVersion
```

2️⃣  ALSO: There's a backend change released recently that bring `creative_review_settings` preference. Tests are now updated.