### PR TITLE
SG-37924 Replace `utcfromtimestamp` for Python 3.12

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -587,9 +587,12 @@ class TestShotgunClient(base.MockTestBase):
         now = datetime.datetime.fromtimestamp(timestamp).replace(
             microsecond=0, tzinfo=SG_TIMEZONE.local
         )
-        utc_now = datetime.datetime.fromtimestamp(
-            timestamp, tz=datetime.timezone.utc
-        ).replace(microsecond=0)
+        utc_now = (
+            datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+            .replace(microsecond=0)
+            .astimezone(None)
+            .replace(tzinfo=None)
+        )
         local = {"date": now.strftime("%Y-%m-%d"), "datetime": now, "time": now.time()}
         # date will still be the local date, because they are not transformed
         utc = {


### PR DESCRIPTION
This pull request includes a small improvement to the `test_transform_data` method in `tests/test_client.py`. The change updates the way UTC timestamps are created to use `datetime.fromtimestamp` with the `tz=datetime.timezone.utc` parameter, replacing the [deprecated use of](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) `datetime.utcfromtimestamp`.