### PR TITLE
Fix misused super in CACertsHTTPSConnection and CACertsHTTPSHandler

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4678,11 +4678,11 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
         """
         # Pop that argument,
         self.__ca_certs = kwargs.pop("ca_certs")
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def connect(self):
         "Connect to a host on a given (SSL) port."
-        super().connect(self)
+        super().connect()
         # Now that the regular HTTP socket has been created, wrap it with our SSL certs.
         if six.PY38:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -4697,13 +4697,13 @@ class CACertsHTTPSConnection(http_client.HTTPConnection):
             )
 
 
-class CACertsHTTPSHandler(urllib.request.HTTPHandler):
+class CACertsHTTPSHandler(urllib.request.HTTPSHandler):
     """
     Handler that ensures https connections are created with the custom CA certs.
     """
 
     def __init__(self, cacerts):
-        super().__init__(self)
+        super().__init__()
         self.__ca_certs = cacerts
 
     def https_open(self, req):


### PR DESCRIPTION
Fix crash when uploading a thumbnail. 

```
$ rez-env python-3.11 sq_shotgun shotgun_api3-3.8.2  -- python -c 'import sq_shotgun; sg = sq_shotgun.connect("Toolkit");  sg.upload("PublishedFile", 123456, "/path/to/no_preview.jpg", field_name="thumb_image")'
Traceback (most recent call last):
(...)
  File "/home-local/rlarouche/packages/shotgun_api3/3.8.2/python/shotgun_api3/shotgun.py", line 4665, in _send_form
    raise ShotgunError("Max attemps limit reached.")
shotgun_api3.shotgun.ShotgunError: Max attemps limit reached.
```

I've isolated the regression to shotgun_api3-3.8.2, more specifically this commit:

https://github.com/shotgunsoftware/python-api/pull/368/files?diff=split&w=0

The issue come from the change in the parent class of `CACertsHTTPSHandler`. 
It was changed from `HTTPSHandler` to `HTTPHandler`. 
This change is weird as the class re-implement `https_open` which don't exist in `HTTPHandler`.

I assume this was done because without changing the parent class, we get the following error:

```
  File "/squeeze/rez_software/rez_package/python/3.11.9/platform-linux/arch-x86_64/os-Rocky-9/lib/python3.11/http/client.py", line 1000, in send
    if self.debuglevel > 0:
       ^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'CACertsHTTPSHandler' and 'int'
```

The reason we get this error is because of how some lines where converted to `super` calls.

They were converted from:

```
urllib.request.HTTPSHandler.__init__(self)
```

To:

```
super().__init__(self)
```

But they should be:

```
super().__init__()
```

Passing `self` to `HTTPSHandler.__init__` will set the `debuglevel` keyword argument, hence the crash.

I hope this helps!