### PR TITLE
SG-40026 Fixup super method should not pass self as first argument

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -4521,11 +4521,11 @@ class CACertsHTTPSConnection(http.client.HTTPConnection):
         """
         # Pop that argument,
         self.__ca_certs = kwargs.pop("ca_certs")
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def connect(self):
         "Connect to a host on a given (SSL) port."
-        super().connect(self)
+        super().connect()
         # Now that the regular HTTP socket has been created, wrap it with our SSL certs.
         if (sys.version_info.major, sys.version_info.minor) >= (3, 8):
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)


### PR DESCRIPTION
This PR is an update of #394 since the PR could not be merged as-is due to recent changes in the repo.

The scope of this PR is exactly the same as #394: Fix misused super in `CACertsHTTPSConnection`.


Closes #394