### PR TITLE
SG-43825 Improve pipeline stability

### DIFF
--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -102,6 +102,8 @@ jobs:
           --durations=0 \
           --nunit-xml=test-results.xml \
           --verbose \
+          --reruns 1 \
+          --reruns-delay 2 \
     env:
       # Tell Pytest that we're running in a CI environment
       CI: 1

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -123,20 +123,42 @@ jobs:
       # This will give a user name like 'something macOS 2.7'
       SG_HUMAN_NAME: $(python_api_human_name) ${{ parameters.os_name }} ${{ parameters.python_version }}
       SG_HUMAN_PASSWORD: $(python_api_human_password)
-      # So, first, we need to make sure that two builds running at the same time do not manipulate
-      # the same entities, so we're sandboxing build nodes based on their name.
-      SG_PROJECT_NAME: Python API CI - $(Agent.Name)
-      # The entities created and then reused between tests assume that the same user is always
-      # manipulating them. Because different builds will be assigned different agents and therefore
-      # different projects, it means each project needs to have an entity specific to a given user.
-      # Again, this would have been a lot simpler if we could simply have had a login based on the
-      # agent name, but alas, the agent name has a space in it which needs to be replaced to something
-      # else and string substitution can't be made on build variables, only template parameters.
-      SG_ASSET_CODE: CI-$(python_api_human_login)-${{ parameters.os_name }}-${{ parameters.python_version }}
-      SG_VERSION_CODE: CI-$(python_api_human_login)-${{ parameters.os_name }}-${{ parameters.python_version }}
-      SG_SHOT_CODE: CI-$(python_api_human_login)-${{ parameters.os_name }}-${{ parameters.python_version }}
-      SG_TASK_CONTENT: CI-$(python_api_human_login)-${{ parameters.os_name }}-${{ parameters.python_version }}
-      SG_PLAYLIST_CODE: CI-$(python_api_human_login)-${{ parameters.os_name }}-${{ parameters.python_version }}
+      # Each job gets its own ephemeral project, scoped to this build + OS + Python version.
+      # This eliminates state bleed between concurrent runs and across successive builds on the
+      # same agent. The project is retired in the "Cleanup test project" step below.
+      SG_PROJECT_NAME: Python API CI - $(Build.BuildId) - ${{ parameters.os_name }} - ${{ parameters.python_version }}
+      # Entity codes only need to be unique within the project, so fixed strings are fine.
+      SG_ASSET_CODE: CI-asset
+      SG_VERSION_CODE: CI-version
+      SG_SHOT_CODE: CI-shot
+      SG_TASK_CONTENT: CI-task
+      SG_PLAYLIST_CODE: CI-playlist
+
+  - task: Bash@3
+    displayName: Cleanup test project
+    condition: always()
+    inputs:
+      targetType: inline
+      script: |
+        python -c "
+        import os, shotgun_api3
+        sg = shotgun_api3.Shotgun(
+            os.environ['SG_SERVER_URL'],
+            os.environ['SG_SCRIPT_NAME'],
+            os.environ['SG_API_KEY'],
+        )
+        project = sg.find_one('Project', [['name', 'is', os.environ['SG_PROJECT_NAME']]])
+        if project:
+            sg.delete('Project', project['id'])
+            print('Retired project:', os.environ['SG_PROJECT_NAME'])
+        else:
+            print('Project not found, nothing to clean up.')
+        "
+    env:
+      SG_SERVER_URL: $(ci_site)
+      SG_SCRIPT_NAME: $(ci_site_script_name)
+      SG_API_KEY: $(ci_site_script_key)
+      SG_PROJECT_NAME: Python API CI - $(Build.BuildId) - ${{ parameters.os_name }} - ${{ parameters.python_version }}
 
   # Explicit call to PublishTestResults@2 and PublishCodeCoverageResults@2 here
   # instead of relying on pytest-azurepipelines because pytest-azurepipelines

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -135,6 +135,7 @@ jobs:
     condition: always()
     inputs:
       scriptSource: inline
+      workingDirectory: $(Build.SourcesDirectory)
       script: |
         import os, shotgun_api3
         sg = shotgun_api3.Shotgun(
@@ -149,6 +150,7 @@ jobs:
         else:
             print('Project not found, nothing to clean up.')
     env:
+      PYTHONPATH: $(Build.SourcesDirectory)
       SG_SERVER_URL: $(ci_site)
       SG_SCRIPT_NAME: $(ci_site_script_name)
       SG_API_KEY: $(ci_site_script_key)

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -147,11 +147,11 @@ jobs:
             entity_type='Project',
             filters=[['name', 'is', os.environ['SG_PROJECT_NAME']]],
         )
-        if project:
-            sg.delete(entity_type='Project', entity_id=project['id'])
-            print('Retired project:', os.environ['SG_PROJECT_NAME'])
-        else:
+        if not project:
             print('Project not found, nothing to clean up.')
+            sys.exit(0)
+        sg.delete(entity_type='Project', entity_id=project['id'])
+        print('Retired project:', os.environ['SG_PROJECT_NAME'])
     env:
       PYTHONPATH: $(Build.SourcesDirectory)
       SG_SERVER_URL: $(ci_site)

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -139,7 +139,7 @@ jobs:
       script: |
         import os, shotgun_api3, sys
         sg = shotgun_api3.Shotgun(
-            base_url=os.environ['SG_SERVER_URL'],
+            os.environ['SG_SERVER_URL'],
             script_name=os.environ['SG_SCRIPT_NAME'],
             api_key=os.environ['SG_API_KEY'],
         )

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -136,13 +136,12 @@ jobs:
       SG_TASK_CONTENT: CI-task
       SG_PLAYLIST_CODE: CI-playlist
 
-  - task: Bash@3
+  - task: PythonScript@0
     displayName: Cleanup test project
     condition: always()
     inputs:
-      targetType: inline
+      scriptSource: inline
       script: |
-        python -c "
         import os, shotgun_api3
         sg = shotgun_api3.Shotgun(
             os.environ['SG_SERVER_URL'],
@@ -155,7 +154,6 @@ jobs:
             print('Retired project:', os.environ['SG_PROJECT_NAME'])
         else:
             print('Project not found, nothing to clean up.')
-        "
     env:
       SG_SERVER_URL: $(ci_site)
       SG_SCRIPT_NAME: $(ci_site_script_name)

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -129,12 +129,6 @@ jobs:
       # This eliminates state bleed between concurrent runs and across successive builds on the
       # same agent. The project is retired in the "Cleanup test project" step below.
       SG_PROJECT_NAME: Python API CI - $(Build.BuildId) - ${{ parameters.os_name }} - ${{ parameters.python_version }}
-      # Entity codes only need to be unique within the project, so fixed strings are fine.
-      SG_ASSET_CODE: CI-asset
-      SG_VERSION_CODE: CI-version
-      SG_SHOT_CODE: CI-shot
-      SG_TASK_CONTENT: CI-task
-      SG_PLAYLIST_CODE: CI-playlist
 
   - task: PythonScript@0
     displayName: Cleanup test project

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -137,7 +137,7 @@ jobs:
       scriptSource: inline
       workingDirectory: $(Build.SourcesDirectory)
       script: |
-        import os, shotgun_api3
+        import os, shotgun_api3, sys
         sg = shotgun_api3.Shotgun(
             base_url=os.environ['SG_SERVER_URL'],
             script_name=os.environ['SG_SCRIPT_NAME'],

--- a/azure-pipelines-templates/run-tests.yml
+++ b/azure-pipelines-templates/run-tests.yml
@@ -139,13 +139,16 @@ jobs:
       script: |
         import os, shotgun_api3
         sg = shotgun_api3.Shotgun(
-            os.environ['SG_SERVER_URL'],
-            os.environ['SG_SCRIPT_NAME'],
-            os.environ['SG_API_KEY'],
+            base_url=os.environ['SG_SERVER_URL'],
+            script_name=os.environ['SG_SCRIPT_NAME'],
+            api_key=os.environ['SG_API_KEY'],
         )
-        project = sg.find_one('Project', [['name', 'is', os.environ['SG_PROJECT_NAME']]])
+        project = sg.find_one(
+            entity_type='Project',
+            filters=[['name', 'is', os.environ['SG_PROJECT_NAME']]],
+        )
         if project:
-            sg.delete('Project', project['id'])
+            sg.delete(entity_type='Project', entity_id=project['id'])
             print('Retired project:', os.environ['SG_PROJECT_NAME'])
         else:
             print('Project not found, nothing to clean up.')

--- a/tests/base.py
+++ b/tests/base.py
@@ -289,7 +289,7 @@ class LiveTestBase(TestBase):
         cls.human_user = _find_or_create_entity(sg, "HumanUser", data)
 
         data = {"code": cls.config.asset_code, "project": cls.project}
-        keys = ["code"]
+        keys = ["code", "project"]
         cls.asset = _find_or_create_entity(sg, "Asset", data, keys)
 
         data = {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,3 +11,4 @@
 pytest
 pytest-cov
 pytest-nunit
+pytest-rerunfailures

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3323,9 +3323,13 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
             self.sg.schema_field_create("Asset", "text", "Project Visibility Test")
 
         # Hide/show on the ephemeral CI project so concurrent matrix jobs do not race.
-        # Use the oldest site project as the control.
+        # Use the oldest site project as the control (find_one defaults to sorting by "id" ascending)
         project_1 = self.project
-        project_2 = self.sg.find_one("Project", [])
+        project_2 = self.sg.find_one("Project", [["id", "is_not", project_1["id"]]])
+        self.assertIsNotNone(
+            project_2,
+            "A second project is required to test per-project field visibility.",
+        )
 
         # First, reset the field visibility in a known state, i.e. visible for both projects,
         # in case the last test run failed midway through.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3322,31 +3322,27 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
         if field_name not in schema:
             self.sg.schema_field_create("Asset", "text", "Project Visibility Test")
 
-        # Grab any two projects that we can use for toggling the visible property with.
-        projects = self.sg.find(
-            "Project", [], order=[{"field_name": "id", "direction": "asc"}]
-        )
-        project_1 = projects[0]
-        project_2 = projects[1]
-
-        def assert_visibility(project, expected, retries=5, delay=1):
-            """Poll until schema_field_read reflects the expected visibility value."""
-            result = None
-            for _ in range(retries):
-                result = self.sg.schema_field_read("Asset", field_name, project)[
-                    field_name
-                ]["visible"]
-                if result == expected:
-                    return
-                time.sleep(delay)
-            self.assertEqual(expected, result)
+        # Hide/show on the ephemeral CI project so concurrent matrix jobs do not race.
+        # Use the oldest site project as the control.
+        project_1 = self.project
+        project_2 = self.sg.find_one("Project", [])
 
         # First, reset the field visibility in a known state, i.e. visible for both projects,
         # in case the last test run failed midway through.
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_1)
-        assert_visibility(project_1, {"value": True, "editable": True})
+        self.assertEqual(
+            {"value": True, "editable": True},
+            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
+                "visible"
+            ],
+        )
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_2)
-        assert_visibility(project_2, {"value": True, "editable": True})
+        self.assertEqual(
+            {"value": True, "editable": True},
+            self.sg.schema_field_read("Asset", field_name, project_2)[field_name][
+                "visible"
+            ],
+        )
 
         # Built-in fields should remain not editable.
         self.assertFalse(
@@ -3362,7 +3358,12 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
         # Hide the field on project 1
         self.sg.schema_field_update("Asset", field_name, {"visible": False}, project_1)
         # It should not be visible anymore.
-        assert_visibility(project_1, {"value": False, "editable": True})
+        self.assertEqual(
+            {"value": False, "editable": True},
+            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
+                "visible"
+            ],
+        )
 
         # The field should be visible on the second project.
         self.assertEqual(
@@ -3374,7 +3375,12 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
 
         # Restore the visibility on the field.
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_1)
-        assert_visibility(project_1, {"value": True, "editable": True})
+        self.assertEqual(
+            {"value": True, "editable": True},
+            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
+                "visible"
+            ],
+        )
 
 
 class TestLibImports(base.LiveTestBase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3329,22 +3329,24 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
         project_1 = projects[0]
         project_2 = projects[1]
 
+        def assert_visibility(project, expected, retries=5, delay=1):
+            """Poll until schema_field_read reflects the expected visibility value."""
+            result = None
+            for _ in range(retries):
+                result = self.sg.schema_field_read("Asset", field_name, project)[
+                    field_name
+                ]["visible"]
+                if result == expected:
+                    return
+                time.sleep(delay)
+            self.assertEqual(expected, result)
+
         # First, reset the field visibility in a known state, i.e. visible for both projects,
         # in case the last test run failed midway through.
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_1)
-        self.assertEqual(
-            {"value": True, "editable": True},
-            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
-                "visible"
-            ],
-        )
+        assert_visibility(project_1, {"value": True, "editable": True})
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_2)
-        self.assertEqual(
-            {"value": True, "editable": True},
-            self.sg.schema_field_read("Asset", field_name, project_2)[field_name][
-                "visible"
-            ],
-        )
+        assert_visibility(project_2, {"value": True, "editable": True})
 
         # Built-in fields should remain not editable.
         self.assertFalse(
@@ -3360,12 +3362,7 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
         # Hide the field on project 1
         self.sg.schema_field_update("Asset", field_name, {"visible": False}, project_1)
         # It should not be visible anymore.
-        self.assertEqual(
-            {"value": False, "editable": True},
-            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
-                "visible"
-            ],
-        )
+        assert_visibility(project_1, {"value": False, "editable": True})
 
         # The field should be visible on the second project.
         self.assertEqual(
@@ -3377,12 +3374,7 @@ class TestReadAdditionalFilterPresets(base.LiveTestBase):
 
         # Restore the visibility on the field.
         self.sg.schema_field_update("Asset", field_name, {"visible": True}, project_1)
-        self.assertEqual(
-            {"value": True, "editable": True},
-            self.sg.schema_field_read("Asset", field_name, project_1)[field_name][
-                "visible"
-            ],
-        )
+        assert_visibility(project_1, {"value": True, "editable": True})
 
 
 class TestLibImports(base.LiveTestBase):


### PR DESCRIPTION
Azure pipelines were occasionally failing for various reasons. Some were transient connection errors (timeouts), but sometimes it was live state issues or test run pollution: only certain runners were failing.

This PR creates ephemeral projects scoped to Build + OS + Python version, so concurrent jobs are fully isolated. These projects are deleted unconditionally on job end.

We also added retries on the tests for the transient error cases.

Also modified `test_modify_visibility`, which was failing unpredictably (likely due to race conditions on using the same existing projects across runners). Now, it uses the ephemeral project for modifying the visibility, and uses the existing project *only* as a control group (so this one should never have it's visibility changed and not affect concurrent executions of `test_modify_visibility`)

Tested multiple times to ensure no more failures due to those identified issues
<img width="1413" height="672" alt="image" src="https://github.com/user-attachments/assets/2b43d037-02cc-42fd-802e-a2f91fd44ffa" />
