### PR TITLE
add __all__ to avoid linting warnings

### DIFF
--- a/shotgun_api3/__init__.py
+++ b/shotgun_api3/__init__.py
@@ -57,3 +57,20 @@ from .shotgun import (
     __version__,
 )
 from .shotgun import SG_TIMEZONE as sg_timezone  # noqa unused imports
+
+# expose imports to avoid linting warnings
+__all__ = [
+    'Shotgun',
+    'ShotgunError',
+    'ShotgunFileDownloadError',
+    'ShotgunThumbnailNotReady',
+    'Fault',
+    'AuthenticationFault',
+    'MissingTwoFactorAuthenticationFault',
+    'UserCredentialsNotAllowedForSSOAuthenticationFault',
+    'ProtocolError',
+    'ResponseError',
+    'Error',
+    '__version__',
+    'sg_timezone',
+]


### PR DESCRIPTION
without __all__ pyright complains that the variables aren't exposed

`"Shotgun" is not exported from module "shotgun_api3" Import from "shotgun_api3.shotgun" instead (Pyright)`

partial fix for issue #445