### PR TITLE
SG-43906 Remove Python 3.7/3.8 compatibility code

### DIFF
--- a/shotgun_api3/__init__.py
+++ b/shotgun_api3/__init__.py
@@ -12,7 +12,7 @@ import os
 import sys
 import warnings
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 9):
     if os.environ.get("SHOTGUN_ALLOW_OLD_PYTHON", "0") != "1":
         # This is our preferred default behavior when using an old
         # unsupported Python version.
@@ -21,23 +21,15 @@ if sys.version_info < (3, 7):
         # Python traceback and trying to understand this is due to using an
         # unsupported Python version.
 
-        raise RuntimeError("This module requires Python version 3.7 or higher.")
+        raise RuntimeError("This module requires Python version 3.9 or higher.")
 
     warnings.warn(
-        "Python versions older than 3.7 are no longer supported as of January "
-        "2023. Since the SHOTGUN_ALLOW_OLD_PYTHON variable is enabled, this "
+        "Python versions older than 3.9 are no longer supported as of March "
+        "2025. Since the SHOTGUN_ALLOW_OLD_PYTHON variable is enabled, this "
         "module is raising a warning instead of an exception. "
         "However, it is very likely that this module will not be able to work "
         "on this Python version.",
         RuntimeWarning,
-        stacklevel=2,
-    )
-elif sys.version_info < (3, 9):
-    warnings.warn(
-        "Python versions older than 3.9 are no longer supported as of March "
-        "2025 and compatibility will be discontinued after March 2026. "
-        "Please update to Python 3.13 or any other supported version.",
-        DeprecationWarning,
         stacklevel=2,
     )
 

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -740,27 +740,18 @@ class Shotgun(object):
         """
         Extract the hostname:port and username/password/token from base_url
         sent when connect to the API.
-
-        In python 3.8 `urllib.parse.splituser` was deprecated warning devs to
-        use `urllib.parse.urlparse`.
         """
-        if (sys.version_info.major, sys.version_info.minor) >= (3, 8):
-            auth = None
-            results = urllib.parse.urlparse(base_url)
-            server = results.hostname
-            if results.port:
-                server = "{}:{}".format(server, results.port)
+        auth = None
+        results = urllib.parse.urlparse(base_url)
+        server = results.hostname
+        if results.port:
+            server = "{}:{}".format(server, results.port)
 
-            if results.username:
-                auth = results.username
+        if results.username:
+            auth = results.username
 
-                if results.password:
-                    auth = "{}:{}".format(auth, results.password)
-
-        else:
-            auth, server = urllib.parse.splituser(
-                urllib.parse.urlsplit(base_url).netloc
-            )
+            if results.password:
+                auth = "{}:{}".format(auth, results.password)
 
         return auth, server
 


### PR DESCRIPTION
## Summary
- Simplify the version guard in `shotgun_api3/__init__.py` to a single 3.9 check, matching the pattern already adopted in tk-core (`c6204ccd`).
- Remove the dead pre-3.8 branch in `Shotgun._split_url()`, which used the deprecated `urllib.parse.splituser`. `setup.py` already requires `python_requires>=3.9.0`, so both the old <3.7 hard-block/<3.9 warning split and the <3.8 URL-parsing branch were unreachable.

## Test plan
- [x] `python3 -m pytest tests/test_unit.py` — 34 passed
- [x] Manual check of `_split_url` against the exact cases in `tests/test_client.py::test_split_url` (auth+port, port only, no auth, numeric-only auth) — all match expected output
- [x] `tests/test_client.py::test_split_url` itself requires a live Shotgun site config not available in this environment — please run in CI

Part of epic SG-36195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)